### PR TITLE
Adding examples on dynamic credentials

### DIFF
--- a/resource-definitions/k8s-cluster-eks/README.md
+++ b/resource-definitions/k8s-cluster-eks/README.md
@@ -1,0 +1,3 @@
+## Connecting to EKS clusters
+
+This section contains example Resource Definitions for connecting to EKS clusters.

--- a/resource-definitions/k8s-cluster-eks/dynamic-credentials/README.md
+++ b/resource-definitions/k8s-cluster-eks/dynamic-credentials/README.md
@@ -1,0 +1,5 @@
+## Using dynamic credentials
+
+This section contains example Resource Definitions using dynamic credentials for connecting to EKS clusters.
+
+* [eks-dynamic-credentials.yaml](eks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).

--- a/resource-definitions/k8s-cluster-eks/dynamic-credentials/eks-dynamic-credentials.yaml
+++ b/resource-definitions/k8s-cluster-eks/dynamic-credentials/eks-dynamic-credentials.yaml
@@ -1,0 +1,20 @@
+# Connect to an EKS cluster using dynmic credentials defined via a Cloud Account
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: eks-dynamic-credentials
+entity:
+  name: eks-dynamic-credentials
+  type: k8s-cluster
+  # The driver_account references a Cloud Account of type "aws-role"
+  # which needs to be configured for your Organization.
+  driver_account: aws-temp-credentials
+  # The driver_type k8s-cluster-eks automatically handles the dynamic credentials
+  # injected via the driver_account.
+  driver_type: humanitec/k8s-cluster-eks
+  driver_inputs:
+    values:
+      region: eu-central-1
+      name: demo-123
+      loadbalancer: x111111xxx111111111x1xx1x111111x-x111x1x11xx111x1.elb.eu-central-1.amazonaws.com
+      loadbalancer_hosted_zone: ABC0DEF5WYYZ00

--- a/resource-definitions/terraform-driver/dynamic-credentials/README.md
+++ b/resource-definitions/terraform-driver/dynamic-credentials/README.md
@@ -1,0 +1,7 @@
+# Dynamic Credentials
+
+Using a Cloud Account type that supports dynamic credentials, those credentials can be easily injected into a Resource Definition using the Terraform Driver. Use a `driver_account` referencing the Cloud Account in the Resource Definition, and access its the credentials through the supplied values as shown in the examples.
+
+## AWS
+
+- [S3 bucket (`s3-dynamic-credentials.yaml`)](./s3-dynamic-credentials.yaml)

--- a/resource-definitions/terraform-driver/dynamic-credentials/s3-dynamic-credentials.yaml
+++ b/resource-definitions/terraform-driver/dynamic-credentials/s3-dynamic-credentials.yaml
@@ -1,0 +1,29 @@
+# Connect to an EKS cluster using dynamic credentials defined via a Cloud Account
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: s3-dynamic-credentials
+entity:
+  name: s3-dynamic-credentials
+  type: s3
+  driver_type: humanitec/terraform
+  # The driver_account references a Cloud Account of type "aws-role"
+  # which needs to be configured for your Organization.
+  driver_account: aws-temp-credentials
+  driver_inputs:
+    values:
+      script: |-
+        # ... Terraform code reduced for brevity
+
+        resource "aws_s3_bucket" "bucket" {
+          bucket = my-bucket
+        }
+      variables:
+        REGION: eu-central-1
+      # Use the credentials injected via the driver_account
+      # to set variables as expected by your Terraform code
+      credentials_config:
+        variables:
+          ACCESS_KEY_ID: AccessKeyId
+          ACCESS_KEY_VALUE: SecretAccessKey
+          SESSION_TOKEN: SessionToken

--- a/resource-definitions/terraform-driver/dynamic-credentials/s3-dynamic-credentials.yaml
+++ b/resource-definitions/terraform-driver/dynamic-credentials/s3-dynamic-credentials.yaml
@@ -12,12 +12,6 @@ entity:
   driver_account: aws-temp-credentials
   driver_inputs:
     values:
-      script: |-
-        # ... Terraform code reduced for brevity
-
-        resource "aws_s3_bucket" "bucket" {
-          bucket = my-bucket
-        }
       variables:
         REGION: eu-central-1
       # Use the credentials injected via the driver_account
@@ -27,3 +21,19 @@ entity:
           ACCESS_KEY_ID: AccessKeyId
           ACCESS_KEY_VALUE: SecretAccessKey
           SESSION_TOKEN: SessionToken
+      script: |-
+        # This provider block is using the Terraform variables
+        # set through the credentials_config.
+        # Variable declarations omitted for brevity.
+        provider "aws" {
+          region     = var.REGION
+          access_key = var.ACCESS_KEY_ID
+          secret_key = var.ACCESS_KEY_VALUE
+          token      = var.SESSION_TOKEN
+        }
+
+        # ... Terraform code reduced for brevity
+
+        resource "aws_s3_bucket" "bucket" {
+          bucket = my-bucket
+        }


### PR DESCRIPTION
This PR adds Resource Definition examples showing how to use dynamic credentials injected via a Cloud Account using the `driver_account` reference. They cover AWS at this point.

Following the contribution guidelines, the example code is reduced on purpose to better highlight what's important: the use of the `driver_account` and, in the case of the Terraform example, the way that variables are automatically populated.

These examples are also meant to be shown on the new Developer Docs page on Cloud Accounts to illustrate the usage of dynamic credentials.