### PR TITLE
fix: fixed up score example to meet spec

### DIFF
--- a/score/files/score.yaml
+++ b/score/files/score.yaml
@@ -8,7 +8,6 @@ containers:
     files:
       - target: /app/default.config
         mode: "0644"
-        content:
-          - |
-            [config]
-            key=value
+        content: |
+          [config]
+          key=value

--- a/score/service/score.yaml
+++ b/score/service/score.yaml
@@ -11,6 +11,6 @@ service:
       port: 8080
       targetPort: 3001
     stream:
-      port: 90245
-      targetPort: 90245
+      port: 19245
+      targetPort: 19245
       protocol: UDP


### PR DESCRIPTION
This PR fixes up 2 of the score examples to meet the score specification updates.

1. Port numbers must be max 65535 (this is a limitation of most networking namespaces in the linux ecosystem)
2. Array-based inline file content is deprecated.

The examples now pass the schema validator.