### PR TITLE
First batch of example pipelines

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,0 +1,3 @@
+## Humanitec Pipelines
+
+This section contains runnable examples for Humanitec Pipelines. They cover a range of commonly needed use cases in a CI/CD setup. Refer to the individual example descriptions for details.

--- a/pipelines/api-triggered-pipelines/run-tests-before-cloning-to-production/README.md
+++ b/pipelines/api-triggered-pipelines/run-tests-before-cloning-to-production/README.md
@@ -1,0 +1,5 @@
+In some environments, continuously deploying all changes from development to production may not be desirable. It may be more important to promote on a manually (or externally) triggered schedule.
+
+The following [Pipeline](pipeline.yaml) can be triggered over the API and will execute tests using GitHub Actions before cloning and deploying.
+
+This Pipeline can now be executed through API requests or by clicking the Run button in the Humanitec Platform Orchestrator UI.

--- a/pipelines/api-triggered-pipelines/run-tests-before-cloning-to-production/pipeline.yaml
+++ b/pipelines/api-triggered-pipelines/run-tests-before-cloning-to-production/pipeline.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   main:
     steps:
-    - uses: actions/humanitec/github-workflow
+    - uses: actions/humanitec/github-workflow@v1
       with:
         repo: my-github-organization/my-github-repository
         ref: main
@@ -25,14 +25,12 @@ jobs:
         access_token: "${{ app.values.github-token }}"
         inputs:
           environment: development
-
-    - uses: actions/humanitec/clone
+    - uses: actions/humanitec/clone@v1
       id: clone
       with:
         from_env_id: development
         to_env_id: production
-    
-    - uses: actions/humanitec/deploy
+    - uses: actions/humanitec/deploy@v1
       with:
         env_id: production
         set_id: ${{ steps.clone.outputs.set_id }}

--- a/pipelines/api-triggered-pipelines/run-tests-before-cloning-to-production/pipeline.yaml
+++ b/pipelines/api-triggered-pipelines/run-tests-before-cloning-to-production/pipeline.yaml
@@ -1,0 +1,39 @@
+name: Promotion
+
+on:
+  pipeline_call:
+    inputs: {}
+
+permissions:
+  application: developer
+  env-types:
+    production: deployer
+
+# we don't want deployments to development happening while we are running tests there
+concurrency:
+  group: blocking-${{ pipeline.app.id }}-development
+
+jobs:
+  main:
+    steps:
+    - uses: actions/humanitec/github-workflow
+      with:
+        repo: my-github-organization/my-github-repository
+        ref: main
+        workflow: ".github/workflows/push.yml"
+        # Read access token from a secret Application value
+        access_token: "${{ app.values.github-token }}"
+        inputs:
+          environment: development
+
+    - uses: actions/humanitec/clone
+      id: clone
+      with:
+        from_env_id: development
+        to_env_id: production
+    
+    - uses: actions/humanitec/deploy
+      with:
+        env_id: production
+        set_id: ${{ steps.clone.outputs.set_id }}
+        comment: Copy of development

--- a/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/README.md
+++ b/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/README.md
@@ -1,0 +1,7 @@
+While automated Continuous Delivery of deployments to a production Environment may be a goal, you may come across scenarios in which a manual approval must be given by a user or external system before promoting a sensitive component or change into an Environment.
+
+In the following [example](pipeline.yaml), Humanitec Pipelines will be used to request a manual approval before cloning a Workload artefact to a production Environment. 
+
+The Pipeline consists of three jobs, `deploy-to-dev`, `wait-for-approval`, and `deploy-to-production`. The dependencies between the jobs are indicated by the `needs` property. `deploy-to-dev` and `deploy-to-production` have the same logic, but target different Environments, while the `wait-for-approval` job will block the Pipeline until a user with the `deployer` role on the `production` Environment approves or denies the approval request which can be retrieved through the user interface or [API](https://api-docs.humanitec.com/#tag/PipelineApprovals).
+
+Note that this Pipeline uses artefact automation and is triggered by uploading a new version of the `myProject/myWorkloadArtefact` Score artefact.

--- a/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
+++ b/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
@@ -16,17 +16,17 @@ permissions:
 jobs:
   deploy-to-dev:
     steps:
-    - uses: actions/humanitec/create-delta
+    - uses: actions/humanitec/create-delta@v1
       id: create
       with:
         env_id: development
         workload_artefacts: ${{ inputs.workload_artefacts }}
-    - uses: actions/humanitec/apply
+    - uses: actions/humanitec/apply@v1
       id: apply
       with:
         env_id: development
         delta_id: ${{ steps.create.outputs.delta_id }}
-    - uses: actions/humanitec/deploy
+    - uses: actions/humanitec/deploy@v1
       with:
         env_id: development
         set_id: ${{ steps.apply.outputs.set_id }}
@@ -38,7 +38,7 @@ jobs:
     needs:
     - deploy-to-dev
     steps:
-    - uses: actions/humanitec/approve
+    - uses: actions/humanitec/approve@v1
       with:
         env_id: production
         message: Promotion of ${{ inputs.workloads[0] }} to production
@@ -47,17 +47,17 @@ jobs:
     needs:
     - deploy-to-production
     steps:
-    - uses: actions/humanitec/create-delta
+    - uses: actions/humanitec/create-delta@v1
       id: create
       with:
         env_id: production
         workloads: ${{ inputs.workloads }}
-    - uses: actions/humanitec/apply
+    - uses: actions/humanitec/apply@v1
       id: apply
       with:
         env_id: production
         delta_id: ${{ steps.create.outputs.delta_id }}
-    - uses: actions/humanitec/deploy
+    - uses: actions/humanitec/deploy@v1
       with:
         env_id: production
         set_id: ${{ steps.apply.outputs.set_id }}

--- a/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
+++ b/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
@@ -1,0 +1,64 @@
+name: Approval before Promotion
+
+on:
+  artefact:
+    type: workload
+    include:
+    - myProject/myWorkloadArtefact
+    ref: refs/heads/main
+
+permissions:
+  application: developer
+  env-types:
+    development: deployer
+    staging: deployer
+
+jobs:
+  deploy-to-dev:
+    steps:
+    - uses: actions/humanitec/create-delta
+      id: create
+      with:
+        env_id: development
+        workload_artefacts: ${{ inputs.workload_artefacts }}
+    - uses: actions/humanitec/apply
+      id: apply
+      with:
+        env_id: development
+        delta_id: ${{ steps.create.outputs.delta_id }}
+    - uses: actions/humanitec/deploy
+      with:
+        env_id: development
+        set_id: ${{ steps.apply.outputs.set_id }}
+        comment: Deploying ${{ inputs.workloads[0] }}
+
+  wait-for-approval:
+    # increase the timeout to 24 hours for this job
+    timeout-minutes: 1440
+    needs:
+    - deploy-to-dev
+    steps:
+    - uses: actions/humanitec/approve
+      with:
+        env_id: production
+        message: Promotion of ${{ inputs.workloads[0] }} to production
+
+  deploy-to-production:
+    needs:
+    - deploy-to-production
+    steps:
+    - uses: actions/humanitec/create-delta
+      id: create
+      with:
+        env_id: production
+        workloads: ${{ inputs.workloads }}
+    - uses: actions/humanitec/apply
+      id: apply
+      with:
+        env_id: production
+        delta_id: ${{ steps.create.outputs.delta_id }}
+    - uses: actions/humanitec/deploy
+      with:
+        env_id: production
+        set_id: ${{ steps.apply.outputs.set_id }}
+        comment: Deploying ${{ inputs.workloads[0] }}

--- a/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
+++ b/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
@@ -5,7 +5,7 @@ on:
     type: workload
     include:
     - myProject/myWorkloadArtefact
-    ref: refs/heads/main
+    match-ref: refs/heads/main
 
 permissions:
   application: developer

--- a/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/README.md
+++ b/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/README.md
@@ -1,0 +1,5 @@
+Humanitec Pipelines supports an `http` action which is able to send external requests with data from the Pipeline execution. This can be used to trigger or notify external systems. One example of this is to notify a channel in Slack or raise a support request or ticket.
+
+In the following example, we’ll notify a Slack channel of the success or failure of all deployments through the Pipeline.
+
+The Slack credential is stored as a secret [Application Shared Value](https://developer.humanitec.com/platform-orchestrator/working-with/shared-values).

--- a/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/pipeline.yaml
+++ b/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/pipeline.yaml
@@ -1,0 +1,51 @@
+name: Deployment with Notifications
+on:
+  deployment_request: {}
+
+# Inherit the permissions of the user triggering the deployment
+permissions:
+  run-as: inherit
+
+jobs:
+  deploy:
+    # This critical property ensures that we don't stop the pipeline when the initial deployment fails.
+    continue-on-error: true
+    steps:
+    - if: ${{ ! inputs.set_id }}
+      name: Create Deployment Set
+      id: create-deployment-set
+      uses: actions/humanitec/apply@v1
+      with:
+        delta_id: ${{ inputs.delta_id }}
+        env_id: ${{ inputs.environment }}
+
+    - name: Deploy Set To Environment
+      uses: actions/humanitec/deploy@v1
+      with:
+        set_id: ${{ inputs.set_id || steps.create-deployment-set.outputs.set_id }}
+        value_set_version_id: ${{ inputs.value_set_version_id }}
+        env_id: ${{ inputs.environment }}
+        message: ${{ inputs.comment }}
+
+  notify:
+    needs: ["deploy"]
+    steps:
+    - name: Notify Slack
+      uses: actions/humanitec/http@v1
+      with: 
+        method: POST
+        url: ${{ app.values.SLACK_WEBHOOK }}
+        headers:
+          "Content-Type": "application/json"
+        data:
+          text: |
+            Deployment to ${{ inputs environment }} ${{ needs.deploy.status }}.
+            Comment: ${{ inputs.comment }}
+            Link: "https://app.humanitec.io/orgs/${{ pipeline.org.id }}/apps/${{ pipeline.app.id }}/envs/${{ inputs.environment }}"
+
+    # Now fail the pipeline if the initial deployment failed
+    - name: Fail if failed
+      if: ${{ needs.deploy.status == 'failed' }}
+      uses: actions/humanitec/fail
+      with:
+        message: Deployment failed.

--- a/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/pipeline.yaml
+++ b/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/pipeline.yaml
@@ -46,6 +46,6 @@ jobs:
     # Now fail the pipeline if the initial deployment failed
     - name: Fail if failed
       if: ${{ needs.deploy.status == 'failed' }}
-      uses: actions/humanitec/fail
+      uses: actions/humanitec/fail@v1
       with:
         message: Deployment failed.

--- a/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/README.md
+++ b/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/README.md
@@ -1,12 +1,12 @@
-In the "[promote between environments](../promote-between-environments-after-a-manual-approval/)" example, a Pipeline is used to promote a Workload from development to production. To ensure that all changes to production have first been tested in development, it may be necessary to block direct deployment of Deltas to production. Deployment request matching criteria can be used for this.
+In the "[promote between environments](../promote-between-environments-after-a-manual-approval/)" example, a Pipeline is used to promote a Workload from development to production. To ensure that all changes to production have first been tested in development, it may be necessary to block direct deployment of Deltas to production. Deployment request Matching Criteria can be used for this.
 
 First, create a [Pipeline](pipeline.yaml) that always fails with a log message.
 
-Then link this Pipeline to the production environment with the following matching criteria:
+Then link this Pipeline to the production Environment with the following Matching Criteria:
 
 - `app_id`: `my-application`
 - `env_id`: `production`
 
 Because this Pipeline is triggered by `deployment_request`, any direct deployments through the user interface and APIs will run through this Pipeline and fail before the deployment takes place.
 
-Deployments through other Pipelines, such as the aforementioned promotion pipeline, will still continue as normal.
+Deployments through other Pipelines, such as the aforementioned promotion Pipeline, will still continue as normal.

--- a/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/README.md
+++ b/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/README.md
@@ -1,0 +1,12 @@
+In the "[promote between environments](../promote-between-environments-after-a-manual-approval/)" example, a Pipeline is used to promote a Workload from development to production. To ensure that all changes to production have first been tested in development, it may be necessary to block direct deployment of Deltas to production. Deployment request matching criteria can be used for this.
+
+First, create a [Pipeline](pipeline.yaml) that always fails with a log message.
+
+Then link this Pipeline to the production environment with the following matching criteria:
+
+- `app_id`: `my-application`
+- `env_id`: `production`
+
+Because this Pipeline is triggered by `deployment_request`, any direct deployments through the user interface and APIs will run through this Pipeline and fail before the deployment takes place.
+
+Deployments through other Pipelines, such as the aforementioned promotion pipeline, will still continue as normal.

--- a/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/pipeline.yaml
+++ b/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/pipeline.yaml
@@ -1,0 +1,11 @@
+name: No deployment allowed
+on:
+  deployment_request: {}
+permissions:
+  application: viewer
+jobs:
+  log:
+    steps:
+    - uses: actions/humanitec/fail
+      with:
+        message: Direct deployment to ${{ inputs.environment }} is not allowed.

--- a/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/pipeline.yaml
+++ b/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/pipeline.yaml
@@ -6,6 +6,6 @@ permissions:
 jobs:
   log:
     steps:
-    - uses: actions/humanitec/fail
+    - uses: actions/humanitec/fail@v1
       with:
         message: Direct deployment to ${{ inputs.environment }} is not allowed.

--- a/pipelines/deployment-pipelines/run-automated-tests-after-deployment/README.md
+++ b/pipelines/deployment-pipelines/run-automated-tests-after-deployment/README.md
@@ -1,13 +1,13 @@
-When the Platform Orchestrator deploys changes into an Environment, the Deployment status indicates whether it successfully provisioned associated resources and configured the Workloads. It does not necessarily imply that the Applications are healthy or that the desired functionality is available to end users. This is why a major part of Continuous Delivery Pipelines is the ability to perform health checks and run a suite of tests against the running application in a pre-production or even production Environment.
+When the Platform Orchestrator deploys changes into an Environment, the Deployment status indicates whether it successfully provisioned associated resources and configured the Workloads. It does not necessarily imply that the Applications are healthy or that the desired functionality is available to end users. This is why a major benefit of Continuous Delivery Pipelines is the ability to perform health checks and run a suite of tests against the running application in a pre-production or even production Environment.
 
 Humanitec Pipelines can be used to achieve this goal by combining the common deployment steps with steps that wait for readiness, and execute external tests in systems such as GitHub Actions or GitLab Pipelines.
 
 The [example Pipeline](pipeline.yaml) uses a GitHub Action.
 
-Once configured for the target environment using deployment request matching criteria, this Pipeline will now fail automatically when any of the following happens:
+Once configured for the target environment using deployment request Matching Criteria, this Pipeline will now fail automatically when any of the following happens:
 
 1. The deployment fails, due to reasons like invalid configuration, inaccessible Kubernetes clusters, or failures to provision resources in the Platform Orchestrator
 1. Workloads that fail to reach a ready state
-1. Failures in the attached GitHub Actions Workflow
+1. Failures occur in the attached GitHub Actions Workflow
 
 All of these events are valuable health tests that can be automated by Humanitec Pipelines.

--- a/pipelines/deployment-pipelines/run-automated-tests-after-deployment/README.md
+++ b/pipelines/deployment-pipelines/run-automated-tests-after-deployment/README.md
@@ -1,0 +1,13 @@
+When the Platform Orchestrator deploys changes into an Environment, the Deployment status indicates whether it successfully provisioned associated resources and configured the Workloads. It does not necessarily imply that the Applications are healthy or that the desired functionality is available to end users. This is why a major part of Continuous Delivery Pipelines is the ability to perform health checks and run a suite of tests against the running application in a pre-production or even production Environment.
+
+Humanitec Pipelines can be used to achieve this goal by combining the common deployment steps with steps that wait for readiness, and execute external tests in systems such as GitHub Actions or GitLab Pipelines.
+
+The [example Pipeline](pipeline.yaml) uses a GitHub Action.
+
+Once configured for the target environment using deployment request matching criteria, this Pipeline will now fail automatically when any of the following happens:
+
+1. The deployment fails, due to reasons like invalid configuration, inaccessible Kubernetes clusters, or failures to provision resources in the Platform Orchestrator
+1. Workloads that fail to reach a ready state
+1. Failures in the attached GitHub Actions Workflow
+
+All of these events are valuable health tests that can be automated by Humanitec Pipelines.

--- a/pipelines/deployment-pipelines/run-automated-tests-after-deployment/pipeline.yaml
+++ b/pipelines/deployment-pipelines/run-automated-tests-after-deployment/pipeline.yaml
@@ -34,12 +34,12 @@ jobs:
         message: ${{ inputs.comment }}
 
     - name: Wait For Ready
-      uses: actions/humanitec/wait-for-readiness
+      uses: actions/humanitec/wait-for-readiness@v1
       with:
         env_id: ${{ inputs.environment }}
  
     - name: Run Tests
-      uses: actions/humanitec/github-workflow
+      uses: actions/humanitec/github-workflow@v1
       with:
         repo: my-github-organization/my-github-repository
         ref: main

--- a/pipelines/deployment-pipelines/run-automated-tests-after-deployment/pipeline.yaml
+++ b/pipelines/deployment-pipelines/run-automated-tests-after-deployment/pipeline.yaml
@@ -1,0 +1,52 @@
+name: Testing after deployment
+
+# This pipeline is a deployment request pipeline and runs for any deploy or re-deploy.
+on:
+  deployment_request: {}
+
+# This pipeline needs permissions to deploy to our development environments. We could add staging and production here too.
+permissions:
+  application: developer
+  env-types:
+    development: deployer
+
+# Because this pipeline runs tests, we're going to use concurrency controls to ensure only one deploy and test cycle is running at a time against the target environment.
+concurrency:
+  group: "${{ pipeline.id }}-${{ pipeline.app.id }}-${{ inputs.environment }}"
+
+jobs:
+  deploy:
+    steps:
+    - if: ${{ ! inputs.set_id }}
+      name: Create Deployment Set
+      id: create-deployment-set
+      uses: actions/humanitec/apply@v1
+      with:
+        delta_id: ${{ inputs.delta_id }}
+        env_id: ${{ inputs.environment }}
+
+    - name: Deploy Set To Environment
+      uses: actions/humanitec/deploy@v1
+      with:
+        set_id: ${{ inputs.set_id || steps.create-deployment-set.outputs.set_id }}
+        value_set_version_id: ${{ inputs.value_set_version_id }}
+        env_id: ${{ inputs.environment }}
+        message: ${{ inputs.comment }}
+
+    - name: Wait For Ready
+      uses: actions/humanitec/wait-for-readiness
+      with:
+        env_id: ${{ inputs.environment }}
+ 
+    - name: Run Tests
+      uses: actions/humanitec/github-workflow
+      with:
+        repo: my-github-organization/my-github-repository
+        ref: main
+        workflow: ".github/workflows/push.yml"
+        # Read access token from a secret Application value
+        access_token: "${{ app.values.github-token }}"
+        # Pass inputs to the pipeline that direct the tests to the target environment
+        inputs:
+          environment: ${{ inputs.environment }}
+        request_uid_input: request_uid


### PR DESCRIPTION
This PR adds a first batch of examples for the new feature of Humanitec Pipelines.

They are structured to support a targeted integration into the developer docs by pipeline type.

Each Pipeline has its own subdir. While this makes for lengthy names, is will provide very verbose headers in the docs. It also allows us to provide extensive descriptions in the individual README files, and great freedom to provide complex examples without being restricted by some taxonomy.