### PR TITLE
credentials from config example

### DIFF
--- a/resource-definitions/terraform-driver/dynamic-credentials-from-config/README.md
+++ b/resource-definitions/terraform-driver/dynamic-credentials-from-config/README.md
@@ -1,0 +1,22 @@
+# Credentials
+
+Different [Terraform providers](https://developer.hashicorp.com/terraform/language/providers) have different ways of being configured. Generally, there are 3 ways that providers can be configured:
+
+- Directly using parameters on the provider. We call this "provider" credentials.
+- Using a credentials file. The filename is supplied to the provider. We call this "file" credentials.
+- Via environment variables that the provider reads. We call this "environment" credentials.
+
+> **NOTE**: At this time, the [Humanitec Terraform driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/terraform/) only supports "provider" and "file" credentials.
+
+The general approach for working with providers is to reference the account from a `config` resource in `driver_account` field.  In this set of examples, we provide two `config` Resource Definitions for AWS and GCP.
+
+## AWS
+
+- [Account config (`account-config-aws.yaml`)](./account-config-aws.yaml)
+- [File Credentials (`aws-file-credentials.yaml`)](./aws-provider-credentials.yaml)
+- [Provider Credentials (`aws-provider-credentials.yaml`)](./aws-file-credentials.yaml)
+
+## GCP
+
+- [Account config (`account-config-gcp.yaml`)](./account-config-gcp.yaml)
+- [File Credentials (`gcp-file-credentials.yaml`)](./gcp-file-credentials.yaml)

--- a/resource-definitions/terraform-driver/dynamic-credentials-from-config/account-config-aws.yaml
+++ b/resource-definitions/terraform-driver/dynamic-credentials-from-config/account-config-aws.yaml
@@ -1,0 +1,17 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: account-config-aws
+entity:
+  criteria:
+    # This res_id is used in the resource reference in the s3-backend Resource Definition.
+    - res_id: aws-account
+
+  # The driver_account references a Cloud Account configured in the Platform Orchestrator.
+  # Replace with the name your AWS Cloud Account.
+  driver_account: aws-credentials
+
+  driver_inputs: {}
+  driver_type: humanitec/template
+  name: account-config-aws
+  type: config

--- a/resource-definitions/terraform-driver/dynamic-credentials-from-config/account-config-gcp.yaml
+++ b/resource-definitions/terraform-driver/dynamic-credentials-from-config/account-config-gcp.yaml
@@ -1,0 +1,17 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: account-config-gcp
+entity:
+  criteria:
+    # This res_id is used in the resource reference in the gcp-file-credentials Resource Definition.
+    - res_id: gcp-account
+
+  # The driver_account references a Cloud Account configured in the Platform Orchestrator.
+  # Replace with the name your GCP Cloud Account.
+  driver_account: gcp-credentials
+
+  driver_inputs: {}
+  driver_type: humanitec/template
+  name: account-config-gcp
+  type: config

--- a/resource-definitions/terraform-driver/dynamic-credentials-from-config/aws-file-credentials.yaml
+++ b/resource-definitions/terraform-driver/dynamic-credentials-from-config/aws-file-credentials.yaml
@@ -1,0 +1,56 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: aws-file-credentials
+entity:
+  # Reference an account from a config resource to allow
+  # using specific credentials for different environments
+  driver_account: ${resources.config#aws-account.account}
+  driver_inputs:
+    # Use the credentials injected via the driver_account
+    # to set variables as expected by your Terraform code
+    credentials_config:
+      file: aws_creds
+    values:
+      script: |-
+
+        variable "region" {}
+
+        terraform {
+          required_providers {
+            aws = {
+              source = "hashicorp/aws"
+            }
+          }
+        }
+
+        provider "aws" {
+          region     = var.region
+
+          # The file is defined above. The provide will read the creds from this file.
+          shared_credentials_files = ["aws_creds"]
+        }
+        
+        output "bucket" {
+          value = aws_s3_bucket.bucket.bucket
+        }
+
+        output "region" {
+          value = var.region
+        }
+
+        resource "aws_s3_bucket" "bucket" {
+          bucket = "$\{replace("${context.res.id}", "^.*\.", "")}-standard-${context.env.id}-${context.app.id}-${context.org.id}"
+          tags = {
+            Humanitec = true
+          }
+        }
+
+      variables:
+        region: us-east-1
+  driver_type: humanitec/terraform
+  name: aws-file-credentials
+  type: s3
+
+  # Supply matching criteria
+  criteria: []

--- a/resource-definitions/terraform-driver/dynamic-credentials-from-config/aws-provider-credentials.yaml
+++ b/resource-definitions/terraform-driver/dynamic-credentials-from-config/aws-provider-credentials.yaml
@@ -1,0 +1,61 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: aws-provider-credentials
+entity:
+  # Reference an account from a config resource to allow
+  # using specific credentials for different environments
+  driver_account: ${resources.config#aws-account.account}
+  driver_inputs:
+    values:
+      # Use the credentials injected via the driver_account
+      # to set variables as expected by your Terraform code
+      credentials_config:
+        variables:
+          ACCESS_KEY_ID: AccessKeyId
+          ACCESS_KEY_VALUE: SecretAccessKey
+          SESSION_TOKEN: SessionToken
+      script: |-
+
+        variable "region" {}
+        variable "aws_access_key_id" {}
+        variable "aws_secret_access_key" {}
+
+        terraform {
+          required_providers {
+            aws = {
+              source = "hashicorp/aws"
+            }
+          }
+        }
+
+        provider "aws" {
+          region     = var.REGION
+          access_key = var.ACCESS_KEY_ID
+          secret_key = var.ACCESS_KEY_VALUE
+          token      = var.SESSION_TOKEN
+        }
+        
+        output "bucket" {
+          value = aws_s3_bucket.bucket.bucket
+        }
+
+        output "region" {
+          value = var.region
+        }
+
+        resource "aws_s3_bucket" "bucket" {
+          bucket = "$\{replace("${context.res.id}", "^.*\.", "")}-standard-${context.env.id}-${context.app.id}-${context.org.id}"
+          tags = {
+            Humanitec = true
+          }
+        }
+
+      variables:
+        region: us-east-1
+  driver_type: humanitec/terraform
+  name: aws-provider-credentials
+  type: s3
+
+  # Supply matching criteria
+  criteria: []

--- a/resource-definitions/terraform-driver/dynamic-credentials-from-config/gcp-file-credentials.yaml
+++ b/resource-definitions/terraform-driver/dynamic-credentials-from-config/gcp-file-credentials.yaml
@@ -1,0 +1,54 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: gcp-file-credentials
+entity:
+  # Reference an account from a config resource to allow
+  # using specific credentials for different environments
+  driver_account: ${resources.config#gcp-account.account}
+  driver_inputs:
+    values:
+      # Use the credentials injected via the driver_account
+      # to set variables as expected by your Terraform code
+      credentials_config:
+        variables:
+          PROJECT_ID: project_id
+        file: credentials.json
+      script: |-
+
+        variable "project_id" {}
+        variable "location" {}
+
+        terraform {
+          required_providers {
+            google = {
+              source = "hashicorp/google"
+            }
+          }
+        }
+
+        provider "google" {
+          project     = var.project_id
+
+          # The file is defined above. The provider will read a service account token from this file.
+          credentials = "credentials.json"
+        }
+        
+        output "name" {
+          value = google_storage_bucket.bucket.name
+        }
+
+        resource "google_storage_bucket" "bucket" {
+          name          = "$\{replace("${context.res.id}", "^.*\.", "")}-standard-${context.env.id}-${context.app.id}-${context.org.id}"
+          location      = var.location
+          force_destroy = true
+        }
+
+      variables:
+        location: US
+  driver_type: humanitec/terraform
+  name: gcp-file-credentials
+  type: gcs
+
+  # Supply matching criteria
+  criteria: []


### PR DESCRIPTION
This example shows using credentials with TF driver. The credentials are defined via Account in a Config resource and referenced in a TF resource (2 examples: AWS and GCP).

The example can replace [another example requested to remove](https://github.com/humanitec-architecture/example-library/pull/5). Actually this is a modified version of that example.

Note: as this is a recommended way, maybe we can remove `dynamic-` from the example name (here and in `dynamic-credentials` example), e.g.:
`dynamic-credential-from-config` -> `credentials`
`dynamic-credentials` -> `credentials-simple`