### PR TITLE
co-provision example

### DIFF
--- a/resource-definitions/terraform-driver/co-provision/README.md
+++ b/resource-definitions/terraform-driver/co-provision/README.md
@@ -5,6 +5,8 @@ This section contains an example of Resource Definitions using the [Terraform Dr
 Scenario: For each AWS S3 bucket resource an AWS IAM policy resource must be created. The bucket properties (region, ARN) should be passed to the policy resource. 
 In other words, an IAM Policy resource depends on a S3 resource, but it needs to be created automatically.
 
+Any time a Resource `R` references a S3 resource using this Resource Definition, an IAM Policy resource will be co-provisioned and reference the S3 resource. The resulting Resource Graph will look like this:
+
 ```mermaid
 flowchart TB
   subgraph fig1 ["<b>S3</b> co-provisions <b>AWS Policy</b>, <b>AWS Policy</b> has a reference to <b>S3</b>"]
@@ -12,12 +14,12 @@ flowchart TB
     R1(R) --->|references| R2(S3)
     N1(AWS Policy) --->|references| R2
   end
-  classDef pClass fill:#fff,stroke:#000,stroke-width:1px
-  classDef rClass fill:#fff,stroke:#000,stroke-width:2px
-  classDef nClass fill:#fff,stroke:#000,stroke-width:2px,stroke-dasharray: 5 5
+  classDef pClass stroke-width:1px
+  classDef rClass stroke-width:2px
+  classDef nClass stroke-width:2px,stroke-dasharray: 5 5
   class R1 pClass
   class R2 rClass
   class N1 nClass
-  classDef subgraphClass fill:#fff,stroke-width:0,white-space:nowrap
+  classDef subgraphClass stroke-width:0,white-space:nowrap
   class fig1 subgraphClass
 ```

--- a/resource-definitions/terraform-driver/co-provision/README.md
+++ b/resource-definitions/terraform-driver/co-provision/README.md
@@ -1,0 +1,7 @@
+## Resource co-provisioning
+
+This section contains an example of Resource Definitions using the [Terraform Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/terraform/) and illustrating the [co-provisioning](https://developer.humanitec.com/platform-orchestrator/resources/resource-graph/#co-provision-resources) concept.
+
+Scenario: For each AWS S3 bucket resource an AWS IAM policy resource must be created. The bucket properties (region, ARN) should be passed to the policy resource. 
+In other words, an IAM Policy resource depends on a S3 resource, but it needs to be created automatically.
+

--- a/resource-definitions/terraform-driver/co-provision/README.md
+++ b/resource-definitions/terraform-driver/co-provision/README.md
@@ -9,7 +9,7 @@ Any time a Resource `R` references a S3 resource using this Resource Definition,
 
 ```mermaid
 flowchart TB
-  subgraph fig1 ["<b>S3</b> co-provisions <b>AWS Policy</b>, <b>AWS Policy</b> has a reference to <b>S3</b>"]
+  subgraph fig1 ["S3 co-provisions AWS Policy, AWS Policy has a reference to S3"]
     direction LR
     R1(R) --->|references| R2(S3)
     N1(AWS Policy) --->|references| R2
@@ -20,6 +20,4 @@ flowchart TB
   class R1 pClass
   class R2 rClass
   class N1 nClass
-  classDef subgraphClass stroke-width:0,white-space:nowrap
-  class fig1 subgraphClass
 ```

--- a/resource-definitions/terraform-driver/co-provision/README.md
+++ b/resource-definitions/terraform-driver/co-provision/README.md
@@ -5,3 +5,19 @@ This section contains an example of Resource Definitions using the [Terraform Dr
 Scenario: For each AWS S3 bucket resource an AWS IAM policy resource must be created. The bucket properties (region, ARN) should be passed to the policy resource. 
 In other words, an IAM Policy resource depends on a S3 resource, but it needs to be created automatically.
 
+```mermaid
+flowchart TB
+  subgraph fig1 ["<b>S3</b> co-provisions <b>AWS Policy</b>, <b>AWS Policy</b> has a reference to <b>S3</b>"]
+    direction LR
+    R1(R) --->|references| R2(S3)
+    N1(AWS Policy) --->|references| R2
+  end
+  classDef pClass fill:#fff,stroke:#000,stroke-width:1px
+  classDef rClass fill:#fff,stroke:#000,stroke-width:2px
+  classDef nClass fill:#fff,stroke:#000,stroke-width:2px,stroke-dasharray: 5 5
+  class R1 pClass
+  class R2 rClass
+  class N1 nClass
+  classDef subgraphClass fill:#fff,stroke-width:0,white-space:nowrap
+  class fig1 subgraphClass
+```

--- a/resource-definitions/terraform-driver/co-provision/README.md
+++ b/resource-definitions/terraform-driver/co-provision/README.md
@@ -5,11 +5,11 @@ This section contains an example of Resource Definitions using the [Terraform Dr
 Scenario: For each AWS S3 bucket resource an AWS IAM policy resource must be created. The bucket properties (region, ARN) should be passed to the policy resource. 
 In other words, an IAM Policy resource depends on a S3 resource, but it needs to be created automatically.
 
-Any time a Resource `R` references a S3 resource using this Resource Definition, an IAM Policy resource will be co-provisioned and reference the S3 resource. The resulting Resource Graph will look like this:
+Any time a Workload references a S3 resource using this Resource Definition, an IAM Policy resource will be co-provisioned and reference the S3 resource. The resulting Resource Graph will look like this:
 
 ```mermaid
 flowchart LR
-  R1(R) --->|references| R2(S3)
+  R1(Workload) --->|references| R2(S3)
   N1(AWS Policy) --->|references| R2
   classDef pClass stroke-width:1px
   classDef rClass stroke-width:2px

--- a/resource-definitions/terraform-driver/co-provision/README.md
+++ b/resource-definitions/terraform-driver/co-provision/README.md
@@ -8,12 +8,9 @@ In other words, an IAM Policy resource depends on a S3 resource, but it needs to
 Any time a Resource `R` references a S3 resource using this Resource Definition, an IAM Policy resource will be co-provisioned and reference the S3 resource. The resulting Resource Graph will look like this:
 
 ```mermaid
-flowchart TB
-  subgraph fig1 ["S3 co-provisions AWS Policy, AWS Policy has a reference to S3"]
-    direction LR
-    R1(R) --->|references| R2(S3)
-    N1(AWS Policy) --->|references| R2
-  end
+flowchart LR
+  R1(R) --->|references| R2(S3)
+  N1(AWS Policy) --->|references| R2
   classDef pClass stroke-width:1px
   classDef rClass stroke-width:2px
   classDef nClass stroke-width:2px,stroke-dasharray: 5 5

--- a/resource-definitions/terraform-driver/co-provision/aws-policy-co-provision.yaml
+++ b/resource-definitions/terraform-driver/co-provision/aws-policy-co-provision.yaml
@@ -1,0 +1,50 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: aws-policy-co-provision
+entity:
+  type: aws-policy
+  driver_type: humanitec/terraform
+  # Use the credentials injected via the driver_account to set variables as expected by your Terraform code
+  driver_account: aws
+  driver_inputs:
+    values:
+      variables:
+        REGION: ${resources.s3.outputs.region}
+        BUCKET: ${resources.s3.outputs.bucket}
+        BUCKET_ARN: ${resources.s3.outputs.arn}
+      credentials_config:
+        variables:
+          ACCESS_KEY_ID: AccessKeyId
+          ACCESS_KEY_VALUE: SecretAccessKey
+      script: |-
+        # This provider block is using the Terraform variables
+        # set through the credentials_config.
+        # Variable declarations omitted for brevity.
+        provider "aws" {
+          region     = var.REGION
+          access_key = var.ACCESS_KEY_ID
+          secret_key = var.ACCESS_KEY_VALUE
+        }
+
+        # ... Terraform code reduced for brevity
+
+        resource "aws_iam_policy" "bucket" {
+          name        = "${var.BUCKET}-policy"
+          policy      = data.aws_iam_policy_document.main.json
+        }
+  
+        data "aws_iam_policy_document" "main" {
+          statement {
+            effect = "Allow"
+  
+            actions = [
+              "s3:GetObject",
+              "s3:ListBucket",
+            ]
+  
+            resources = [
+              var.BUCKET_ARN,
+            ]
+          }
+}

--- a/resource-definitions/terraform-driver/co-provision/s3-co-provision.yaml
+++ b/resource-definitions/terraform-driver/co-provision/s3-co-provision.yaml
@@ -46,4 +46,4 @@ entity:
   # Co-provision aws-policy resource
   provision:
     aws-policy:
-      is_dependent: true
+      is_dependent: false

--- a/resource-definitions/terraform-driver/co-provision/s3-co-provision.yaml
+++ b/resource-definitions/terraform-driver/co-provision/s3-co-provision.yaml
@@ -1,0 +1,49 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: s3-co-provision
+entity:
+  name: s3-co-provision
+  type: s3
+  driver_type: humanitec/terraform
+  # Use the credentials injected via the driver_account to set variables as expected by your Terraform code
+  driver_account: aws
+  driver_inputs:
+    values:
+      variables:
+        REGION: eu-central-1
+      credentials_config:
+        variables:
+          ACCESS_KEY_ID: AccessKeyId
+          ACCESS_KEY_VALUE: SecretAccessKey
+      script: |-
+        # This provider block is using the Terraform variables
+        # set through the credentials_config.
+        # Variable declarations omitted for brevity.
+        provider "aws" {
+          region     = var.REGION
+          access_key = var.ACCESS_KEY_ID
+          secret_key = var.ACCESS_KEY_VALUE
+        }
+
+        # ... Terraform code reduced for brevity
+
+        resource "aws_s3_bucket" "bucket" {
+          bucket = my-bucket
+        }
+        
+        output "bucket" {
+          value = aws_s3_bucket.main.id
+        }
+  
+        output "arn" {
+          value = aws_s3_bucket.main.arn
+        }
+          
+        output "region" {
+          value = aws_s3_bucket.main.region
+        }
+  # Co-provision aws-policy resource
+  provision:
+    aws-policy:
+      is_dependent: true


### PR DESCRIPTION
This is a simple example of co-provisioning (S3 -> AWS Policy).

It's possible to come up with one big example illustrating co-provisioning, selectors and classes (as they give together a powerful combination). But I decided to create smaller examples first.

To come next:
- Selectors example (uses co-provisioning too).
- Classes example (uses co-provisioning too).