### PR TITLE
Showing the use of Shared Values for files

### DIFF
--- a/score/environment-variables/score.yaml
+++ b/score/environment-variables/score.yaml
@@ -6,4 +6,8 @@ containers:
   demo:
     image: registry/my-image:1.0.0
     variables:
-      API_KEY: "${values.API_KEY}"
+      API_KEY: "${resources.env.API_KEY}"
+resources:
+  env:
+    # The type "environment" is available per the Score specification.
+    type: environment

--- a/score/files/README.md
+++ b/score/files/README.md
@@ -1,3 +1,9 @@
 Add files to Containers.
 
 Refer to the [files feature](https://developer.humanitec.com/integration-and-extensions/workload-profiles/features/#humaniteccontainers---files) for configuration details.
+
+The examples show these variations to provide file content:
+
+* [score.yaml](./score.yaml): Base approach supplying the file contents as a multiline string. This approach creates the same file content across all environments.
+* [score-shared-values.yaml](./score-shared-values.yaml): (Recommended) Supplying the file contents via a [Shared Value](https://developer.humanitec.com/platform-orchestrator/working-with/shared-values/) via the `environment` resource which is available as part of the [Score specification](https://docs.score.dev/docs/environment-variables/environment-variables-humanitec/). Since Shared Values may optionally be overridden on an Environment level, this approach lets you inject environment-specific configuration managed through the Platform Orchestrator.
+* [score-local-file-source.yaml](./score-local-file-source.yaml): Supplying the file contents via a file available locally which is read at Score deployment time, i.e. when executing `score-humanitec delta --deploy`.

--- a/score/files/appsettings.json
+++ b/score/files/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "key1": "value1",
+  "key2": "value2",
+  "key3": "value3"
+}

--- a/score/files/score-local-file-source.yaml
+++ b/score/files/score-local-file-source.yaml
@@ -1,0 +1,13 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: my-workload
+
+containers:
+  demo:
+    image: registry/my-image:1.0.0
+    files:
+      - target: /app/default.config
+        mode: "0644"
+        # The source references a locally available file
+        # It is read by the score-humanitec CLI when running "score-humanitec delta --deploy"
+        source: "./appsettings.json"

--- a/score/files/score-shared-values.yaml
+++ b/score/files/score-shared-values.yaml
@@ -1,0 +1,16 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: my-workload
+
+containers:
+  demo:
+    image: registry/my-image:1.0.0
+    files:
+      - target: /app/default.config
+        mode: "0644"
+        # The content references the Shared Value APP_SETTINGS, available through the "env" resource declared below
+        content: "${resources.env.APP_SETTINGS}"
+resources:
+  env:
+    # The type "environment" is available per the Score specification
+    type: environment


### PR DESCRIPTION
This PR adds Score examples showing the use of Shared Values for files, as well as one other variation of adding files via Score using a local source file.