### PR TITLE
Add "source" spec for volume

### DIFF
--- a/score/volumes/humanitec.score.yaml
+++ b/score/volumes/humanitec.score.yaml
@@ -8,3 +8,5 @@ spec:
   volumes:
     tmp-pod:
       type: emptyDir
+      source:
+        sizeLimit: "1024Mi"


### PR DESCRIPTION
Align the "volume" example with the [current example on the features page](https://developer.humanitec.com/integration-and-extensions/workload-profiles/features/#humanitecvolumes) for subsequent sourcing of that example from the example-library.