### PR TITLE
Correcting input to Deployment Pipeline example

### DIFF
--- a/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/pipeline.yaml
+++ b/pipelines/deployment-pipelines/notify-slack-channel-of-failed-deployments/pipeline.yaml
@@ -17,14 +17,14 @@ jobs:
       uses: actions/humanitec/apply@v1
       with:
         delta_id: ${{ inputs.delta_id }}
-        env_id: ${{ inputs.environment }}
+        env_id: ${{ inputs.env_id }}
 
     - name: Deploy Set To Environment
       uses: actions/humanitec/deploy@v1
       with:
         set_id: ${{ inputs.set_id || steps.create-deployment-set.outputs.set_id }}
         value_set_version_id: ${{ inputs.value_set_version_id }}
-        env_id: ${{ inputs.environment }}
+        env_id: ${{ inputs.env_id }}
         message: ${{ inputs.comment }}
 
   notify:

--- a/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/pipeline.yaml
+++ b/pipelines/deployment-pipelines/prevent-direct-deployment-to-production/pipeline.yaml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/humanitec/fail@v1
       with:
-        message: Direct deployment to ${{ inputs.environment }} is not allowed.
+        message: Direct deployment to ${{ inputs.env_id }} is not allowed.

--- a/pipelines/deployment-pipelines/run-automated-tests-after-deployment/pipeline.yaml
+++ b/pipelines/deployment-pipelines/run-automated-tests-after-deployment/pipeline.yaml
@@ -12,7 +12,7 @@ permissions:
 
 # Because this pipeline runs tests, we're going to use concurrency controls to ensure only one deploy and test cycle is running at a time against the target environment.
 concurrency:
-  group: "${{ pipeline.id }}-${{ pipeline.app.id }}-${{ inputs.environment }}"
+  group: "${{ pipeline.id }}-${{ pipeline.app.id }}-${{ inputs.env_id }}"
 
 jobs:
   deploy:
@@ -23,20 +23,20 @@ jobs:
       uses: actions/humanitec/apply@v1
       with:
         delta_id: ${{ inputs.delta_id }}
-        env_id: ${{ inputs.environment }}
+        env_id: ${{ inputs.env_id }}
 
     - name: Deploy Set To Environment
       uses: actions/humanitec/deploy@v1
       with:
         set_id: ${{ inputs.set_id || steps.create-deployment-set.outputs.set_id }}
         value_set_version_id: ${{ inputs.value_set_version_id }}
-        env_id: ${{ inputs.environment }}
+        env_id: ${{ inputs.env_id }}
         message: ${{ inputs.comment }}
 
     - name: Wait For Ready
       uses: actions/humanitec/wait-for-readiness@v1
       with:
-        env_id: ${{ inputs.environment }}
+        env_id: ${{ inputs.env_id }}
  
     - name: Run Tests
       uses: actions/humanitec/github-workflow@v1
@@ -48,5 +48,5 @@ jobs:
         access_token: "${{ app.values.github-token }}"
         # Pass inputs to the pipeline that direct the tests to the target environment
         inputs:
-          environment: ${{ inputs.environment }}
+          environment: ${{ inputs.env_id }}
         request_uid_input: request_uid


### PR DESCRIPTION
Setting the outdated Deployment Pipeline Input "environment" to the updated "env_id" in all Deployment Pipeline examples.