### PR TITLE
Add concurrency group to "Approval" pipeline

### DIFF
--- a/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/README.md
+++ b/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/README.md
@@ -5,3 +5,5 @@ In the following [example](pipeline.yaml), Humanitec Pipelines will be used to r
 The Pipeline consists of three jobs, `deploy-to-dev`, `wait-for-approval`, and `deploy-to-production`. The dependencies between the jobs are indicated by the `needs` property. `deploy-to-dev` and `deploy-to-production` have the same logic, but target different Environments, while the `wait-for-approval` job will block the Pipeline until a user with the `deployer` role on the `production` Environment approves or denies the approval request which can be retrieved through the user interface or [API](https://api-docs.humanitec.com/#tag/PipelineApprovals).
 
 Note that this Pipeline uses artefact automation and is triggered by uploading a new version of the `myProject/myWorkloadArtefact` Score artefact.
+
+The Pipeline also makes use of a [concurrency group](https://developer.humanitec.com/integration-and-extensions/humanitec-pipelines/specification/#concurrency) ensuring that subsequent runs are queued and deployment sequences from development to production do not overlap.

--- a/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
+++ b/pipelines/artefact-automation-pipelines/promote-between-environments-after-approval/pipeline.yaml
@@ -7,6 +7,9 @@ on:
     - myProject/myWorkloadArtefact
     match-ref: refs/heads/main
 
+concurrency:
+  group: myGroup
+
 permissions:
   application: developer
   env-types:


### PR DESCRIPTION
This PR expands the "Approval before Promotion" example pipeline by a concurrency group and explains the rationale in the related README.