### PR TITLE
Add k8s-cluster-git resource definition

### DIFF
--- a/resource-definitions/k8s-cluster-git/README.md
+++ b/resource-definitions/k8s-cluster-git/README.md
@@ -1,0 +1,3 @@
+## Connecting to a Git repository (GitOps mode)
+
+This section contains example Resource Definitions for connecting to a Git repository to push application CRs ([GitOps mode](https://developer.humanitec.com/integration-and-extensions/humanitec-operator/architecture/#modes-of-operation-humanitec-operator-with-gitops)).

--- a/resource-definitions/k8s-cluster-git/static-credentials/README.md
+++ b/resource-definitions/k8s-cluster-git/static-credentials/README.md
@@ -1,0 +1,5 @@
+## Using static credentials
+
+This section contains example Resource Definitions using static credentials for connecting to a Git repository in ([GitOps mode](https://developer.humanitec.com/integration-and-extensions/humanitec-operator/architecture/#modes-of-operation-humanitec-operator-with-gitops)).
+
+* [github-for-gitops.yaml](github-for-gitops.yaml): use static credentials defined via GitHub variables. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).

--- a/resource-definitions/k8s-cluster-git/static-credentials/github-for-gitops.yaml
+++ b/resource-definitions/k8s-cluster-git/static-credentials/github-for-gitops.yaml
@@ -19,3 +19,5 @@ entity:
     secrets:
       credentials:
         ssh_key: ${GIT_SSH_KEY}
+        # Alternative to ssh_key: password or Personal Account Token
+        # password: ${GIT_PAT}

--- a/resource-definitions/k8s-cluster-git/static-credentials/github-for-gitops.yaml
+++ b/resource-definitions/k8s-cluster-git/static-credentials/github-for-gitops.yaml
@@ -1,0 +1,21 @@
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: github-for-gitops
+entity:
+  name: github-for-gitops
+  driver_type: humanitec/k8s-cluster-git
+  type: k8s-cluster
+  driver_inputs:
+    values:
+      # Git repository for pushing manifests
+      url: git@github.com:example-org/gitops-repo.git
+      # Branch in the git repository, optional. If not specified, the default branch is used.
+      branch: development
+      # Path in the git repository, optional. If not specified, the root is used.
+      path: "${context.app.id}/${context.env.id}"
+      # Load Balancer, optional. Though it's not related to the git, it's used to create ingress in the target K8s cluster.
+      loadbalancer: 35.10.10.10
+    secrets:
+      credentials:
+        ssh_key: ${GIT_SSH_KEY}


### PR DESCRIPTION
This is an example of `k8s-cluster` resource definition, created with git driver and used in the GitOps approach.