### PR TITLE
Expand labels example

### DIFF
--- a/resource-definitions/template-driver/labels/README.md
+++ b/resource-definitions/template-driver/labels/README.md
@@ -1,3 +1,7 @@
-This section contains example Resource Definitions using the [Template Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/template/) for managing [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) on Kubernetes objects.
+This section shows how to use the [Template Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/template/) for managing [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) on Kubernetes objects.
 
+While it is also possible to [set labels via Score](https://developer.humanitec.com/examples/score/labels/), the approach shown here shifts the management of labels down to the Platform, ensuring consistency and relieving developers of the task to repeat common labels for each Workload in the Score extension file.
+
+* [`config-labels.yaml`](config-labels.yaml): Resource Definition of type [`config`](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#config) which defines the value for a sample label at a central place.
 * [`custom-workload-with-dynamic-labels.yaml`](./custom-workload-with-dynamic-labels.yaml): Add dynamic labels to your Workload. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
+* [`custom-namespace-with-dynamic-labels.yaml`](custom-namespace-with-dynamic-labels.yaml): Add dynamic labels to your Namespace. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).

--- a/resource-definitions/template-driver/labels/config-labels.yaml
+++ b/resource-definitions/template-driver/labels/config-labels.yaml
@@ -1,0 +1,18 @@
+# This "config" type Resource Definition provides the value for the sample label
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: app-config
+entity:
+  name: app-config
+  type: config
+  driver_type: humanitec/template
+  driver_inputs:
+    values:
+      templates:
+        # Returns a sample output named "substream_id" to be used as a label
+        outputs: |
+          substream_id: my-example-id
+  # Set matching criteria as required
+  criteria:
+    - {}

--- a/resource-definitions/template-driver/labels/config-labels.yaml
+++ b/resource-definitions/template-driver/labels/config-labels.yaml
@@ -10,9 +10,9 @@ entity:
   driver_inputs:
     values:
       templates:
-        # Returns a sample output named "substream_id" to be used as a label
+        # Returns a sample output named "cost_center_id" to be used as a label
         outputs: |
-          substream_id: my-example-id
-  # Set matching criteria as required
+          cost_center_id: my-example-id
+  # Match the resource ID "app-config" so that it can be requested via that ID
   criteria:
-    - {}
+    - res_id: app-config

--- a/resource-definitions/template-driver/labels/custom-namespace-with-dynamic-labels.yaml
+++ b/resource-definitions/template-driver/labels/custom-namespace-with-dynamic-labels.yaml
@@ -1,0 +1,31 @@
+# This Resource Definition references the "config" resource to use its output as a label
+# and adds another label taken from the Deployment context
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: custom-namespace-with-label
+entity:
+  name: custom-namespace-with-label
+  type: k8s-namespace
+  driver_type: humanitec/template
+  driver_inputs:
+    values:
+      templates:
+        init: |
+          name: ${context.app.id}-${context.env.id}
+        manifests: |-
+          namespace.yaml:
+            location: cluster
+            data:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                labels:
+                  env_type: ${context.env.id}
+                  substream_id: ${resources['config.default#app-config'].outputs.substream_id}
+                name: {{ .init.name }}
+        outputs: |
+          namespace: {{ .init.name }}
+  # Set matching criteria as required
+  criteria:
+    - {}

--- a/resource-definitions/template-driver/labels/custom-namespace-with-dynamic-labels.yaml
+++ b/resource-definitions/template-driver/labels/custom-namespace-with-dynamic-labels.yaml
@@ -21,8 +21,8 @@ entity:
               kind: Namespace
               metadata:
                 labels:
-                  env_type: ${context.env.id}
-                  substream_id: ${resources['config.default#app-config'].outputs.substream_id}
+                  env_id: ${context.env.id}
+                  cost_center_id: ${resources['config.default#app-config'].outputs.cost_center_id}
                 name: {{ .init.name }}
         outputs: |
           namespace: {{ .init.name }}

--- a/resource-definitions/template-driver/labels/custom-workload-with-dynamic-labels.yaml
+++ b/resource-definitions/template-driver/labels/custom-workload-with-dynamic-labels.yaml
@@ -1,15 +1,17 @@
+# This Resource Definition references the "config" resource to use its output as a label
+# and adds another label taken from the Deployment context
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: custom-workload
+  id: custom-workload-with-label
 entity:
-  name: custom-workload
+  name: custom-workload-with-label
   type: workload
   driver_type: humanitec/template
   driver_inputs:
     values:
       templates:
-        # Remove the /spec/service/labels part if there no "service" in your Score file.
+        # Remove the /spec/service/labels part if there is no "service" in your Score file.
         outputs: |
           update:
             - op: add
@@ -18,15 +20,16 @@ entity:
                 {{- range $key, $val := .resource.spec.labels }}
                 {{ $key }}: {{ $val | quote }}
                 {{- end }}
-                testtest: testtest
-                substream_id: ${resources.base-env.outputs.substream_id}
+                env_type: ${context.env.id}
+                substream_id: ${resources['config.default#app-config'].outputs.substream_id}
             - op: add
               path: /spec/service/labels
               value:
                 {{- range $key, $val := .resource.spec.service.labels }}
                 {{ $key }}: {{ $val | quote }}
                 {{- end }}
-                testtest: testtest
-                substream_id: ${resources.base-env.outputs.substream_id}
+                env_type: ${context.env.id}
+                substream_id: ${resources['config.default#app-config'].outputs.substream_id}
+  # Set matching criteria as required
   criteria:
     - {}

--- a/resource-definitions/template-driver/labels/custom-workload-with-dynamic-labels.yaml
+++ b/resource-definitions/template-driver/labels/custom-workload-with-dynamic-labels.yaml
@@ -20,16 +20,16 @@ entity:
                 {{- range $key, $val := .resource.spec.labels }}
                 {{ $key }}: {{ $val | quote }}
                 {{- end }}
-                env_type: ${context.env.id}
-                substream_id: ${resources['config.default#app-config'].outputs.substream_id}
+                env_id: ${context.env.id}
+                cost_center_id: ${resources['config.default#app-config'].outputs.cost_center_id}
             - op: add
               path: /spec/service/labels
               value:
                 {{- range $key, $val := .resource.spec.service.labels }}
                 {{ $key }}: {{ $val | quote }}
                 {{- end }}
-                env_type: ${context.env.id}
-                substream_id: ${resources['config.default#app-config'].outputs.substream_id}
+                env_id: ${context.env.id}
+                cost_center_id: ${resources['config.default#app-config'].outputs.cost_center_id}
   # Set matching criteria as required
   criteria:
     - {}


### PR DESCRIPTION
This PR expands the Template Driver example for labels. It now covers setting labels on both Workload and Namespace, and switches to using a `config` Resource instead of the `base-env` for greater flexibility.