### PR TITLE
Added workload example for AKS virtual nodes

### DIFF
--- a/resource-definitions/template-driver/node-selector/README.md
+++ b/resource-definitions/template-driver/node-selector/README.md
@@ -1,0 +1,3 @@
+This section contains example Resource Definitions using the [Template Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/template/) for setting [nodeSelectors](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) on your Pods.
+
+* [`aci-workload.yaml`](./aci-workload.yaml): Add the required node selector and tolerations to the Workload so it can be scheduled on an [Azure AKS virtual node](https://learn.microsoft.com/en-us/azure/aks/virtual-nodes). This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).

--- a/resource-definitions/template-driver/node-selector/aci-workload.yaml
+++ b/resource-definitions/template-driver/node-selector/aci-workload.yaml
@@ -1,0 +1,30 @@
+# Add tolerations and nodeSelector to the Workload to make it runnable AKS virtual nodes
+# served through Azure Container Instances (ACI).
+# See https://learn.microsoft.com/en-us/azure/aks/virtual-nodes-cli
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: aci-workload
+entity:
+  name: aci-workload
+  type: workload
+  driver_type: humanitec/template
+  driver_inputs:
+    values:
+      templates:
+        outputs: |
+          update: 
+          - op: add
+            path: /spec/tolerations
+            value:
+            - key: "virtual-kubelet.io/provider"
+              operator: "Exists"
+            - key: "azure.com/aci"
+              effect: "NoSchedule"
+          - op: add
+            path: /spec/nodeSelector
+            value:
+              kubernetes.io/role: agent
+              beta.kubernetes.io/os: linux
+              type: virtual-kubelet
+  criteria: []


### PR DESCRIPTION
This PR adds an example for defining both a `nodeSelector` and `toleration` on a Workload. I created it while (successfully) testing the deployment of Workloads to [AKS virtual nodes](https://learn.microsoft.com/en-us/azure/aks/virtual-nodes).

The data for the Workload elements is taken from https://learn.microsoft.com/en-us/azure/aks/virtual-nodes-cli

While the example could also have been placed in the `tolerations` folder, I considered it more helpful to open up and thus cover the `nodeselector` category.

Once merged, the example will be linked from a new developer docs page on deploying to serverless offerings.