### PR TITLE
Example for GKE dynamic credentials

### DIFF
--- a/resource-definitions/k8s-cluster-gke/dynamic-credentials/README.md
+++ b/resource-definitions/k8s-cluster-gke/dynamic-credentials/README.md
@@ -1,0 +1,5 @@
+## Using dynamic credentials
+
+This section contains example Resource Definitions using dynamic credentials for connecting to GKE clusters.
+
+* [gke-dynamic-credentials.yaml](gke-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).

--- a/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.yaml
+++ b/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.yaml
@@ -1,0 +1,18 @@
+# Connect to a GKE cluster using dynamic credentials defined via a Cloud Account
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: gke-dynamic-credentials-cloudaccount
+entity:
+  name: gke-dynamic-credentials-cloudaccount
+  type: k8s-cluster
+  # The driver_account references a Cloud Account of type "gcp-identity"
+  # which needs to be configured for your Organization.
+  driver_account: gcp-dynamic-creds
+  driver_type: humanitec/k8s-cluster-gke
+  driver_inputs:
+    values:
+      loadbalancer: 35.10.10.10
+      name: demo-123
+      zone: europe-west2-a
+      project_id: my-gcp-project


### PR DESCRIPTION
This PR adds an example Resource Definition for a `k8s-cluster` type using the `k8s-cluster-gke` Driver and dynamic credentials via a Cloud Account.

Once published, the example file can be integrated into the developer docs page on GCP Cloud Accounts.