### PR TITLE
Added example for AKS dynamic credentials

### DIFF
--- a/resource-definitions/k8s-cluster-aks/dynamic-credentials/README.md
+++ b/resource-definitions/k8s-cluster-aks/dynamic-credentials/README.md
@@ -1,0 +1,5 @@
+## Using dynamic credentials
+
+This section contains example Resource Definitions using dynamic credentials for connecting to AKS clusters.
+
+* [aks-dynamic-credentials.yaml](aks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).

--- a/resource-definitions/k8s-cluster-aks/dynamic-credentials/aks-dynamic-credentials.yaml
+++ b/resource-definitions/k8s-cluster-aks/dynamic-credentials/aks-dynamic-credentials.yaml
@@ -1,0 +1,20 @@
+# Connect to an AKS cluster using dynamic credentials defined via a Cloud Account
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: aks-dynamic-credentials
+entity:
+  name: aks-dynamic-credentials
+  type: k8s-cluster
+  # The driver_account references a Cloud Account of type "azure-identity"
+  # which needs to be configured for your Organization.
+  driver_account: azure-dynamic-creds
+  driver_type: humanitec/k8s-cluster-aks
+  driver_inputs:
+    values:
+      loadbalancer: 20.10.10.10
+      name: demo-123
+      resource_group: my-resources
+      subscription_id: 12345678-aaaa-bbbb-cccc-0987654321ba
+      # Add this exact server_app_id for a cluster using AKS-managed Entra ID integration
+      # server_app_id: 6dae42f8-4368-4678-94ff-3960e28e3630


### PR DESCRIPTION
This PR adds an example for a `k8s-cluster` Resource Definitionf for AKS using a dynamic credentials Cloud Account.