### PR TITLE
Kubernetes Agent examples and Terraform variants

### DIFF
--- a/resource-definitions/k8s-cluster-aks/agent/README.md
+++ b/resource-definitions/k8s-cluster-aks/agent/README.md
@@ -1,4 +1,4 @@
-## Using dynamic credentials
+## Using the Humanitec Agent
 
 This section contains example Resource Definitions using the [Humanitec Agent](https://developer.humanitec.com/integration-and-extensions/humanitec-agent/overview/) for connecting to AKS clusters.
 

--- a/resource-definitions/k8s-cluster-aks/agent/README.md
+++ b/resource-definitions/k8s-cluster-aks/agent/README.md
@@ -1,0 +1,6 @@
+## Using dynamic credentials
+
+This section contains example Resource Definitions using the [Humanitec Agent](https://developer.humanitec.com/integration-and-extensions/humanitec-agent/overview/) for connecting to AKS clusters.
+
+* [aks-agent.yaml](aks-agent.yaml): uses a Cloud Account as well as the Humanitec Agent to access this private cluster. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
+* [aks-agent.tf](aks-agent.tf): uses a Cloud Account as well as the Humanitec Agent to access this private cluster. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
+++ b/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
@@ -1,0 +1,24 @@
+# AKS private cluster. It is to be accessed via the Humanitec Agent
+# It is using a Cloud Account to obtain credentials
+resource "humanitec_resource_definition" "aks-private-dev-dynamic-credentials" {
+  id          = "aks-agent"
+  name        = "aks-agent"
+  type        = "k8s-cluster"
+  driver_type = "humanitec/k8s-cluster-aks"
+  # The driver_account is referring to a Cloud Account resource
+  driver_account = humanitec_resource_account.azure-dynamic.id
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "name"            = var.azure_aks_private_cluster_name
+      "resource_group"  = var.azure_aks_resource_group
+      "subscription_id" = var.azure_subscription_id
+      # Add this exact server_app_id for a cluster using AKS-managed Entra ID integration
+      # "server_app_id" = "6dae42f8-4368-4678-94ff-3960e28e3630"
+    })
+    # Setting the URL for the Humanitec Agent
+    secrets_string = jsonencode({
+      "agent_url" = "$${resources['agent#agent'].outputs.url}"
+    })
+  }
+}

--- a/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
+++ b/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
@@ -1,6 +1,6 @@
 # AKS private cluster. It is to be accessed via the Humanitec Agent
 # It is using a Cloud Account to obtain credentials
-resource "humanitec_resource_definition" "aks-private-dev-dynamic-credentials" {
+resource "humanitec_resource_definition" "aks-agent" {
   id          = "aks-agent"
   name        = "aks-agent"
   type        = "k8s-cluster"

--- a/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
+++ b/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
@@ -11,6 +11,7 @@ resource "humanitec_resource_definition" "aks-agent" {
   driver_inputs = {
     values_string = jsonencode({
       "name"            = var.azure_aks_private_cluster_name
+      "loadbalancer"    = var.azure_aks_private_cluster_loadbalancer
       "resource_group"  = var.azure_aks_resource_group
       "subscription_id" = var.azure_subscription_id
       # Add this exact server_app_id for a cluster using AKS-managed Entra ID integration

--- a/resource-definitions/k8s-cluster-aks/agent/aks-agent.yaml
+++ b/resource-definitions/k8s-cluster-aks/agent/aks-agent.yaml
@@ -1,0 +1,22 @@
+# Connect to an AKS cluster using dynamic credentials defined via a Cloud Account
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: aks-agent
+entity:
+  name: aks-agent
+  type: k8s-cluster
+  # The driver_account is referring to a Cloud Account configured in your Organization
+  driver_account: azure-dynamic-creds
+  driver_type: humanitec/k8s-cluster-aks
+  driver_inputs:
+    secrets:
+      # Setting the URL for the Humanitec Agent
+      agent_url: "${resources['agent#agent'].outputs.url}"
+    values:
+      loadbalancer: 20.10.10.10
+      name: demo-123
+      resource_group: my-resources
+      subscription_id: 12345678-aaaa-bbbb-cccc-0987654321ba
+      # Add this exact server_app_id for a cluster using AKS-managed Entra ID integration
+      # server_app_id: 6dae42f8-4368-4678-94ff-3960e28e3630

--- a/resource-definitions/k8s-cluster-aks/dynamic-credentials/README.md
+++ b/resource-definitions/k8s-cluster-aks/dynamic-credentials/README.md
@@ -1,5 +1,6 @@
 ## Using dynamic credentials
 
-This section contains example Resource Definitions using dynamic credentials for connecting to AKS clusters.
+This section contains example Resource Definitions using [dynamic credentials](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/azure/#azure-workload-identity-federation) for connecting to AKS clusters.
 
-* [aks-dynamic-credentials.yaml](aks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
+* [aks-dynamic-credentials.yaml](aks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
+* [aks-dynamic-credentials.tf](aks-dynamic-credentials.tf): uses dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-aks/dynamic-credentials/aks-dynamic-credentials.tf
+++ b/resource-definitions/k8s-cluster-aks/dynamic-credentials/aks-dynamic-credentials.tf
@@ -1,15 +1,16 @@
 # AKS private cluster. It is using a Cloud Account with dynamic credentials
 resource "humanitec_resource_definition" "aks-dynamic-credentials" {
-  id             = "aks-dynamic-credentials"
-  name           = "aks-dynamic-credentials"
-  type           = "k8s-cluster"
-  driver_type    = "humanitec/k8s-cluster-aks"
+  id          = "aks-dynamic-credentials"
+  name        = "aks-dynamic-credentials"
+  type        = "k8s-cluster"
+  driver_type = "humanitec/k8s-cluster-aks"
   # The driver_account is referring to a Cloud Account resource
   driver_account = humanitec_resource_account.azure-dynamic.id
 
   driver_inputs = {
     values_string = jsonencode({
       "name"            = var.azure_aks_private_cluster_name
+      "loadbalancer"    = var.azure_aks_private_cluster_loadbalancer
       "resource_group"  = var.azure_aks_resource_group
       "subscription_id" = var.azure_subscription_id
       # Add this exact server_app_id for a cluster using AKS-managed Entra ID integration

--- a/resource-definitions/k8s-cluster-aks/dynamic-credentials/aks-dynamic-credentials.tf
+++ b/resource-definitions/k8s-cluster-aks/dynamic-credentials/aks-dynamic-credentials.tf
@@ -1,0 +1,19 @@
+# AKS private cluster. It is using a Cloud Account with dynamic credentials
+resource "humanitec_resource_definition" "aks-dynamic-credentials" {
+  id             = "aks-dynamic-credentials"
+  name           = "aks-dynamic-credentials"
+  type           = "k8s-cluster"
+  driver_type    = "humanitec/k8s-cluster-aks"
+  # The driver_account is referring to a Cloud Account resource
+  driver_account = humanitec_resource_account.azure-dynamic.id
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "name"            = var.azure_aks_private_cluster_name
+      "resource_group"  = var.azure_aks_resource_group
+      "subscription_id" = var.azure_subscription_id
+      # Add this exact server_app_id for a cluster using AKS-managed Entra ID integration
+      # "server_app_id" = "6dae42f8-4368-4678-94ff-3960e28e3630"
+    })
+  }
+}

--- a/resource-definitions/k8s-cluster-aks/static-credentials/aks-static-credentials.yaml
+++ b/resource-definitions/k8s-cluster-aks/static-credentials/aks-static-credentials.yaml
@@ -1,4 +1,5 @@
-
+# NOTE: Providing inline credentials as shown in this example is discouraged and will be deprecated.
+# Using a Cloud Account is the recommended approach instead.
 # Make sure all ${ENVIRONMENT_VARIABLES} are set when applying this Resource Definition.
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition

--- a/resource-definitions/k8s-cluster-eks/agent/README.md
+++ b/resource-definitions/k8s-cluster-eks/agent/README.md
@@ -1,0 +1,6 @@
+## Using dynamic credentials
+
+This section contains example Resource Definitions using the [Humanitec Agent](https://developer.humanitec.com/integration-and-extensions/humanitec-agent/overview/) for connecting to EKS clusters.
+
+* [eks-agent.yaml](eks-agent.yaml): uses a Cloud Account as well as the Humanitec Agent to access this private cluster. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
+* [eks-agent.tf](eks-agent.tf): uses a Cloud Account as well as the Humanitec Agent to access this private cluster. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-eks/agent/README.md
+++ b/resource-definitions/k8s-cluster-eks/agent/README.md
@@ -1,4 +1,4 @@
-## Using dynamic credentials
+## Using the Humanitec Agent
 
 This section contains example Resource Definitions using the [Humanitec Agent](https://developer.humanitec.com/integration-and-extensions/humanitec-agent/overview/) for connecting to EKS clusters.
 

--- a/resource-definitions/k8s-cluster-eks/agent/eks-agent.tf
+++ b/resource-definitions/k8s-cluster-eks/agent/eks-agent.tf
@@ -1,0 +1,21 @@
+# EKS private cluster. It is to be accessed via the Humanitec Agent
+# It is using a Cloud Account with dynamic credentials
+resource "humanitec_resource_definition" "eks-agent" {
+  id          = "eks-agent"
+  name        = "eks-agent"
+  type        = "k8s-cluster"
+  driver_type = "humanitec/k8s-cluster-eks"
+  # The driver_account is referring to a Cloud Account resource
+  driver_account = humanitec_resource_account.aws-dynamic.id
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "name"   = var.eks_cluster_name
+      "region" = var.aws_region
+    })
+    # Setting the URL for the Humanitec Agent
+    secrets_string = jsonencode({
+      "agent_url" = "$${resources['agent#agent'].outputs.url}"
+    })
+  }
+}

--- a/resource-definitions/k8s-cluster-eks/agent/eks-agent.tf
+++ b/resource-definitions/k8s-cluster-eks/agent/eks-agent.tf
@@ -10,8 +10,10 @@ resource "humanitec_resource_definition" "eks-agent" {
 
   driver_inputs = {
     values_string = jsonencode({
-      "name"   = var.eks_cluster_name
-      "region" = var.aws_region
+      "name"                     = var.eks_cluster_name
+      "region"                   = var.aws_region
+      "loadbalancer"             = var.eks_loadbalancer
+      "loadbalancer_hosted_zone" = var.eks_loadbalancer_hostedzone
     })
     # Setting the URL for the Humanitec Agent
     secrets_string = jsonencode({

--- a/resource-definitions/k8s-cluster-eks/agent/eks-agent.yaml
+++ b/resource-definitions/k8s-cluster-eks/agent/eks-agent.yaml
@@ -1,0 +1,20 @@
+# Connect to an EKS cluster using dynamic credentials defined via a Cloud Account
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: eks-agent
+entity:
+  name: eks-agent
+  type: k8s-cluster
+  # The driver_account is referring to a Cloud Account configured in your Organization
+  driver_account: aws-temp-creds
+  driver_type: humanitec/k8s-cluster-eks
+  driver_inputs:
+    secrets:
+      # Setting the URL for the Humanitec Agent
+      agent_url: "${resources['agent#agent'].outputs.url}"
+    values:
+      region: eu-central-1
+      name: demo-123
+      loadbalancer: x111111xxx111111111x1xx1x111111x-x111x1x11xx111x1.elb.eu-central-1.amazonaws.com
+      loadbalancer_hosted_zone: ABC0DEF5WYYZ00

--- a/resource-definitions/k8s-cluster-eks/dynamic-credentials/README.md
+++ b/resource-definitions/k8s-cluster-eks/dynamic-credentials/README.md
@@ -2,4 +2,5 @@
 
 This section contains example Resource Definitions using dynamic credentials for connecting to EKS clusters.
 
-* [eks-dynamic-credentials.yaml](eks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
+* [eks-dynamic-credentials.yaml](eks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
+* [eks-dynamic-credentials.tf](eks-dynamic-credentials.tf): uses dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-eks/dynamic-credentials/eks-dynamic-credentials.tf
+++ b/resource-definitions/k8s-cluster-eks/dynamic-credentials/eks-dynamic-credentials.tf
@@ -1,0 +1,16 @@
+# EKS private cluster. It is using a Cloud Account with dynamic credentials
+resource "humanitec_resource_definition" "eks-dynamic-credentials" {
+  id             = "eks-dynamic-credentials"
+  name           = "eks-dynamic-credentials"
+  type           = "k8s-cluster"
+  driver_type    = "humanitec/k8s-cluster-eks"
+  # The driver_account is referring to a Cloud Account resource
+  driver_account = humanitec_resource_account.aws-dynamic.id
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "name"   = var.eks_cluster_name
+      "region" = var.aws_region
+    })
+  }
+}

--- a/resource-definitions/k8s-cluster-eks/dynamic-credentials/eks-dynamic-credentials.tf
+++ b/resource-definitions/k8s-cluster-eks/dynamic-credentials/eks-dynamic-credentials.tf
@@ -1,16 +1,18 @@
 # EKS private cluster. It is using a Cloud Account with dynamic credentials
 resource "humanitec_resource_definition" "eks-dynamic-credentials" {
-  id             = "eks-dynamic-credentials"
-  name           = "eks-dynamic-credentials"
-  type           = "k8s-cluster"
-  driver_type    = "humanitec/k8s-cluster-eks"
+  id          = "eks-dynamic-credentials"
+  name        = "eks-dynamic-credentials"
+  type        = "k8s-cluster"
+  driver_type = "humanitec/k8s-cluster-eks"
   # The driver_account is referring to a Cloud Account resource
   driver_account = humanitec_resource_account.aws-dynamic.id
 
   driver_inputs = {
     values_string = jsonencode({
-      "name"   = var.eks_cluster_name
-      "region" = var.aws_region
+      "name"                     = var.eks_cluster_name
+      "region"                   = var.aws_region
+      "loadbalancer"             = var.eks_loadbalancer
+      "loadbalancer_hosted_zone" = var.eks_loadbalancer_hostedzone
     })
   }
 }

--- a/resource-definitions/k8s-cluster-eks/static-credentials/eks-static-credentials.yaml
+++ b/resource-definitions/k8s-cluster-eks/static-credentials/eks-static-credentials.yaml
@@ -1,3 +1,5 @@
+# NOTE: Providing inline credentials as shown in this example is discouraged and will be deprecated.
+# Using a Cloud Account is the recommended approach instead.
 # Make sure all ${ENVIRONMENT_VARIABLES} are set when applying this Resource Definition.
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition

--- a/resource-definitions/k8s-cluster-gke/agent/README.md
+++ b/resource-definitions/k8s-cluster-gke/agent/README.md
@@ -1,4 +1,4 @@
-## Using dynamic credentials
+## Using the Humanitec Agent
 
 This section contains example Resource Definitions using the [Humanitec Agent](https://developer.humanitec.com/integration-and-extensions/humanitec-agent/overview/) for connecting to GKE clusters.
 

--- a/resource-definitions/k8s-cluster-gke/agent/README.md
+++ b/resource-definitions/k8s-cluster-gke/agent/README.md
@@ -1,0 +1,6 @@
+## Using dynamic credentials
+
+This section contains example Resource Definitions using the [Humanitec Agent](https://developer.humanitec.com/integration-and-extensions/humanitec-agent/overview/) for connecting to GKE clusters.
+
+* [gke-agent.yaml](gke-agent.yaml): uses a Cloud Account as well as the Humanitec Agent to access this private cluster. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
+* [gke-agent.tf](gke-agent.tf): uses a Cloud Account as well as the Humanitec Agent to access this private cluster. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-gke/agent/gke-agent.tf
+++ b/resource-definitions/k8s-cluster-gke/agent/gke-agent.tf
@@ -10,9 +10,10 @@ resource "humanitec_resource_definition" "gke-agent" {
 
   driver_inputs = {
     values_string = jsonencode({
-      "name"       = var.gke_cluster_name
-      "project_id" = var.gcp_project_id
-      "zone"       = var.gcp_region
+      "name"         = var.gke_cluster_name
+      "loadbalancer" = var.gke_loadbalancer
+      "project_id"   = var.gcp_project_id
+      "zone"         = var.gcp_region
     })
     # Setting the URL for the Humanitec Agent
     secrets_string = jsonencode({

--- a/resource-definitions/k8s-cluster-gke/agent/gke-agent.tf
+++ b/resource-definitions/k8s-cluster-gke/agent/gke-agent.tf
@@ -1,0 +1,22 @@
+# EKS private cluster. It is to be accessed via the Humanitec Agent
+# It is using a Cloud Account with dynamic credentials
+resource "humanitec_resource_definition" "gke-agent" {
+  id          = "gke-agent"
+  name        = "gke-agent"
+  type        = "k8s-cluster"
+  driver_type = "humanitec/k8s-cluster-gke"
+  # The driver_account is referring to a Cloud Account resource
+  driver_account = humanitec_resource_account.gcp-dynamic.id
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "name"       = var.gke_cluster_name
+      "project_id" = var.gcp_project_id
+      "zone"       = var.gcp_region
+    })
+    # Setting the URL for the Humanitec Agent
+    secrets_string = jsonencode({
+      "agent_url" = "$${resources['agent#agent'].outputs.url}"
+    })
+  }
+}

--- a/resource-definitions/k8s-cluster-gke/agent/gke-agent.yaml
+++ b/resource-definitions/k8s-cluster-gke/agent/gke-agent.yaml
@@ -1,0 +1,21 @@
+# EKS private cluster. It is to be accessed via the Humanitec Agent
+# It is using a Cloud Account with dynamic credentials
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: gke-agent
+entity:
+  name: gke-agent
+  type: k8s-cluster
+  # The driver_account is referring to a Cloud Account configured in your Organization
+  driver_account: gcp-dynamic-creds
+  driver_type: humanitec/k8s-cluster-gke
+  driver_inputs:
+    secrets:
+      # Setting the URL for the Humanitec Agent
+      agent_url: "${resources['agent#agent'].outputs.url}"
+    values:
+      loadbalancer: 35.10.10.10
+      name: demo-123
+      zone: europe-west2-a
+      project_id: my-gcp-project

--- a/resource-definitions/k8s-cluster-gke/dynamic-credentials/README.md
+++ b/resource-definitions/k8s-cluster-gke/dynamic-credentials/README.md
@@ -2,4 +2,5 @@
 
 This section contains example Resource Definitions using dynamic credentials for connecting to GKE clusters.
 
-* [gke-dynamic-credentials.yaml](gke-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
+* [gke-dynamic-credentials.yaml](gke-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
+* [gke-dynamic-credentials.tf](gke-dynamic-credentials.tf): uses dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.tf
+++ b/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.tf
@@ -1,0 +1,17 @@
+# GKE private cluster. It is using a Cloud Account with dynamic credentials
+resource "humanitec_resource_definition" "gke-dynamic" {
+  id             = "gke-dynamic"
+  name           = "gke-dynamic"
+  type           = "k8s-cluster"
+  driver_type    = "humanitec/k8s-cluster-gke"
+  # The driver_account references a Cloud Account of type "gcp-identity"
+  driver_account = humanitec_resource_account.gcp-dynamic.id
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "name"       = var.gke_cluster_name
+      "project_id" = var.gcp_project_id
+      "zone"       = var.gcp_region
+    })
+  }
+}

--- a/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.tf
+++ b/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.tf
@@ -1,17 +1,18 @@
 # GKE private cluster. It is using a Cloud Account with dynamic credentials
 resource "humanitec_resource_definition" "gke-dynamic" {
-  id             = "gke-dynamic"
-  name           = "gke-dynamic"
-  type           = "k8s-cluster"
-  driver_type    = "humanitec/k8s-cluster-gke"
+  id          = "gke-dynamic"
+  name        = "gke-dynamic"
+  type        = "k8s-cluster"
+  driver_type = "humanitec/k8s-cluster-gke"
   # The driver_account references a Cloud Account of type "gcp-identity"
   driver_account = humanitec_resource_account.gcp-dynamic.id
 
   driver_inputs = {
     values_string = jsonencode({
-      "name"       = var.gke_cluster_name
-      "project_id" = var.gcp_project_id
-      "zone"       = var.gcp_region
+      "name"         = var.gke_cluster_name
+      "loadbalancer" = var.gke_loadbalancer
+      "project_id"   = var.gcp_project_id
+      "zone"         = var.gcp_region
     })
   }
 }

--- a/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.yaml
+++ b/resource-definitions/k8s-cluster-gke/dynamic-credentials/gke-dynamic-credentials.yaml
@@ -2,9 +2,9 @@
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: gke-dynamic-credentials-cloudaccount
+  id: gke-dynamic-credentials
 entity:
-  name: gke-dynamic-credentials-cloudaccount
+  name: gke-dynamic-credentials
   type: k8s-cluster
   # The driver_account references a Cloud Account of type "gcp-identity"
   # which needs to be configured for your Organization.

--- a/resource-definitions/k8s-cluster-gke/static-credentials/gke-static-credentials.yaml
+++ b/resource-definitions/k8s-cluster-gke/static-credentials/gke-static-credentials.yaml
@@ -1,4 +1,6 @@
 
+# NOTE: Providing inline credentials as shown in this example is discouraged and will be deprecated.
+# Using a Cloud Account is the recommended approach instead.
 # Make sure all ${ENVIRONMENT_VARIABLES} are set when applying this Resource Definition.
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition


### PR DESCRIPTION
This PR adds missing Resource Definition examples for `k8s-cluster` type resources:

- Examples showing how to configure the [Humanitec Agent](https://developer.humanitec.com/integration-and-extensions/humanitec-agent/overview/)
  - This will create a new capability "Agent" in the [Example Library](https://developer.humanitec.com/examples/resource-definitions/) once integrated
- Supplemental Terraform examples along the existing YAML variants

The PR also adds a preemptive note on the upcoming deprecation of inline credentials for `k8s-cluster` Resource Definition in favor of Cloud Accounts.