### PR TITLE
Adding TF example for generic k8s

### DIFF
--- a/resource-definitions/k8s-cluster/static-credentials/README.md
+++ b/resource-definitions/k8s-cluster/static-credentials/README.md
@@ -2,4 +2,5 @@
 
 This section contains example Resource Definitions using static credentials for connecting to generic Kubernetes clusters.
 
+* [generic-k8s-client-certificate.tf](generic-k8s-client-certificate.tf): use a [client certificate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certificates) to connect to the cluster. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)
 * [generic-k8s-static-credentials.yaml](generic-k8s-client-certificate.yaml): use a [client certificate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certificates) to connect to the cluster. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).

--- a/resource-definitions/k8s-cluster/static-credentials/generic-k8s-client-certificate.tf
+++ b/resource-definitions/k8s-cluster/static-credentials/generic-k8s-client-certificate.tf
@@ -1,0 +1,26 @@
+# Provide access to the kubeconfig file
+locals {
+  parsed_kubeconfig = yamldecode(file("/path/to/kubeconfig"))
+}
+
+# Resource Definition for a generic Kubernetes cluster
+resource "humanitec_resource_definition" "generic_cluster" {
+  id          = "generic-k8s-static-credentials"
+  name        = "generic-k8s-static-credentials"
+  type        = "k8s-cluster"
+  driver_type = "humanitec/k8s-cluster"
+
+  driver_inputs = {
+    values_string = jsonencode({
+      loadbalancer = "35.10.10.10"
+      # The index [0] assumes the target cluster is the first cluster definition
+      cluster_data = local.parsed_kubeconfig["clusters"][0]["cluster"]
+    })
+    secrets_string = jsonencode({
+      # Setting the URL for the Humanitec Agent. Remove the line if not used
+      agent_url   = "$${resources['agent#agent'].outputs.url}"
+      # The index [0] assumes the target user is the first user definition
+      credentials = local.parsed_kubeconfig["users"][0]["user"]
+    })
+  }
+}

--- a/resource-definitions/k8s-cluster/static-credentials/generic-k8s-client-certificate.yaml
+++ b/resource-definitions/k8s-cluster/static-credentials/generic-k8s-client-certificate.yaml
@@ -1,3 +1,4 @@
+# Resource Definition for a generic Kubernetes cluster
 # Make sure all ${ENVIRONMENT_VARIABLES} are set when applying this Resource Definition.
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition


### PR DESCRIPTION
This PR adds a missing example for a generic `k8s-cluster` Resource Definition using Terraform.

It is adapted from the code used in the [5-min-IDP](https://github.com/humanitec-tutorials/5min-idp/blob/d80dfb1b29f36c477cb30acd3937b4371714d300/setup/terraform/idp-cluster.tf#L73).