### PR TITLE
Example for using a private image registry

### DIFF
--- a/resource-definitions/template-driver/imagepullsecrets/README.md
+++ b/resource-definitions/template-driver/imagepullsecrets/README.md
@@ -1,0 +1,12 @@
+This section shows how to use the [Template Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/template/) for configuring cluster access to a private container image registry.
+
+The example implements the Kubernetes standard mechanism to [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). It creates a Kubernetes Secret of `kubernetes.io/dockerconfigjson` type, reading the credentials from a secret store. The example therefore requires the [Humanitec Operator](https://developer.humanitec.com/integration-and-extensions/humanitec-operator/overview/) to be set up for the cluster.
+
+The example then configures the secret as the `imagePullSecret` for a Workload's Pod.
+
+To use this mechanism, install the Resource Definitions of this example into your Organization, and add the appropriate [matching criteria](https://developer.humanitec.com/platform-orchestrator/resources/resource-definitions/#matching-criteria) to the `workload` Definition to match the Workloads you want to have access to the private registry.
+
+> Note: `workload` is an [implicit Resource Type](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#resource-type-use) so it is automatically referenced for every Deployment.
+
+- [config.yaml](config.yaml): Resource Definition of `type: config` that reads the credentials for the private registry from a secret store and creates the Kubernetes Secret
+- [workload.yaml](workload.yaml): Resource Definition of `type: workload` that adds the `imagePullSecrets` element to the Pod spec, referencing the `config` Resource

--- a/resource-definitions/template-driver/imagepullsecrets/README.md
+++ b/resource-definitions/template-driver/imagepullsecrets/README.md
@@ -1,10 +1,10 @@
 This section shows how to use the [Template Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/template/) for configuring cluster access to a private container image registry.
 
-The example implements the Kubernetes standard mechanism to [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). It creates a Kubernetes Secret of `kubernetes.io/dockerconfigjson` type, reading the credentials from a secret store. The example therefore requires the [Humanitec Operator](https://developer.humanitec.com/integration-and-extensions/humanitec-operator/overview/) to be set up for the cluster.
+The example implements the Kubernetes standard mechanism to [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). It creates a Kubernetes Secret of `kubernetes.io/dockerconfigjson` type, reading the credentials from a secret store. It then configures the secret as the `imagePullSecret` for a Workload's Pod.
 
-The example then configures the secret as the `imagePullSecret` for a Workload's Pod.
+The example is applicable only when using the [Humanitec Operator](https://developer.humanitec.com/integration-and-extensions/humanitec-operator/overview/) on the cluster. With the Operator, using the [Registries](https://developer.humanitec.com/integration-and-extensions/ci-cd/integrate/#container-registries) feature of the Platform Orchestrator is not supported.
 
-To use this mechanism, install the Resource Definitions of this example into your Organization, and add the appropriate [matching criteria](https://developer.humanitec.com/platform-orchestrator/resources/resource-definitions/#matching-criteria) to the `workload` Definition to match the Workloads you want to have access to the private registry.
+To use this mechanism, install the Resource Definitions of this example into your Organization, replacing some placeholder values with the actual values of your setup. Add the appropriate [matching criteria](https://developer.humanitec.com/platform-orchestrator/resources/resource-definitions/#matching-criteria) to the `workload` Definition to match the Workloads you want to have access to the private registry.
 
 > Note: `workload` is an [implicit Resource Type](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#resource-type-use) so it is automatically referenced for every Deployment.
 

--- a/resource-definitions/template-driver/imagepullsecrets/config.yaml
+++ b/resource-definitions/template-driver/imagepullsecrets/config.yaml
@@ -1,0 +1,50 @@
+# This Resource Definition pulls credentials for a container image registry from a secret store
+# and creates a Kubernetes Secret of kubernetes.io/dockerconfigjson type
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: regcred-config
+entity:
+  driver_type: humanitec/template
+  name: regcred-config
+  type: config
+  criteria:
+  - class: default
+    # This res_id must be used from a referencing Resource Definition to request this config Resource
+    res_id: regcred
+  driver_inputs:
+    # These secret references read the credentials from a secret store
+    secret_refs:
+      password:
+        ref: regcred-password
+        store: FIXME
+      username:
+        ref: regcred-username
+        store: FIXME
+    values:
+      secret_name: regcred
+      # Define the container registry server
+      server: FIXME
+      templates:
+        # The init template is used to prepare the "dockerConfigJson" content
+        init: |
+          dockerConfigJson:
+            auths:
+              {{ .driver.values.server | quote }}:
+                username: {{ .driver.secrets.username | toRawJson }}
+                password: {{ .driver.secrets.password | toRawJson }}
+        manifests:
+          # The manifests template creates the Kubernetes Secret
+          # which can then be used in the workload "imagePullSecrets"
+          regcred-secret.yaml:
+            data: |
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: {{ .driver.values.secret_name }}
+              data:
+                .dockerconfigjson: {{ .init.dockerConfigJson | toRawJson | b64enc }}
+              type: kubernetes.io/dockerconfigjson
+            location: namespace
+        outputs: |
+          secret_name: {{ .driver.values.secret_name }}

--- a/resource-definitions/template-driver/imagepullsecrets/config.yaml
+++ b/resource-definitions/template-driver/imagepullsecrets/config.yaml
@@ -17,13 +17,15 @@ entity:
     secret_refs:
       password:
         ref: regcred-password
+        # Replace this value with the secret store id that's supplying the password
         store: FIXME
       username:
         ref: regcred-username
+        # Replace this value with the secret store id that's supplying the username
         store: FIXME
     values:
       secret_name: regcred
-      # Define the container registry server
+      # Replace this value with the servername of your registry
       server: FIXME
       templates:
         # The init template is used to prepare the "dockerConfigJson" content

--- a/resource-definitions/template-driver/imagepullsecrets/workload.yaml
+++ b/resource-definitions/template-driver/imagepullsecrets/workload.yaml
@@ -16,4 +16,4 @@ entity:
             - op: add
               path: /spec/imagePullSecrets
               value:
-                - name: \${resources["config.default#regcred"].outputs.secret_name}
+                - name: ${resources["config.default#regcred"].outputs.secret_name}

--- a/resource-definitions/template-driver/imagepullsecrets/workload.yaml
+++ b/resource-definitions/template-driver/imagepullsecrets/workload.yaml
@@ -1,0 +1,19 @@
+# This workload Resource Definition adds an "imagePullSecrets" element to the Pod spec
+# It references a "config" type Resource to obtain the secret name
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: custom-workload
+entity:
+  name: custom-workload
+  type: workload
+  driver_type: humanitec/template
+  driver_inputs:
+    values:
+      templates:
+        outputs: |
+          update:
+            - op: add
+              path: /spec/imagePullSecrets
+              value:
+                - name: \${resources["config.default#regcred"].outputs.secret_name}


### PR DESCRIPTION
This example shows how to use the [Template Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/template/) for configuring cluster access to a private container image registry.

Once merged in this repo, we can link to the example from relevant pages in the developer docs.