### PR TITLE
Fixing generic cluster Resource Definition

### DIFF
--- a/resource-definitions/k8s-cluster/static-credentials/generic-k8s-client-certificate.yaml
+++ b/resource-definitions/k8s-cluster/static-credentials/generic-k8s-client-certificate.yaml
@@ -10,13 +10,14 @@ entity:
   driver_type: humanitec/k8s-cluster
   driver_inputs:
     values:
-      name: my-generic-k8s-cluster
       loadbalancer: 35.10.10.10
       cluster_data:
         server: https://35.11.11.11:6443
         # Single line base64-encoded cluster CA data in the format "LS0t...ca-data....=="
         certificate-authority-data: ${CLUSTER_CERTIFICATE_CA_DATA}
     secrets:
+      # Setting the URL for the Humanitec Agent. Remove the line if not used
+      agent_url: "${resources['agent#agent'].outputs.url}"
       credentials:
         # Single line base64-encoded client certificate data in the format "LS0t...cert-data...=="
         client-certificate-data: ${USER_CLIENT_CERTIFICATE_DATA}


### PR DESCRIPTION
This PR removes the unsupported field `name` from the Driver input `values` in the generic YAML cluster Resource Definition.

For conformance with its Terraform sibling, it also adds the optional `agent_url` to illustrate this capacity.