### PR TITLE
Adding Ingress example Resource Definitions

### DIFF
--- a/resource-definitions/ingress/README.md
+++ b/resource-definitions/ingress/README.md
@@ -1,0 +1,3 @@
+## Creating Ingress objects
+
+This section contains example Resource Definitions for creating [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) objects using the [Ingress](https://developer.humanitec.com/integration-and-extensions/drivers/k8-drivers/ingress/) Driver.

--- a/resource-definitions/ingress/alb/README.md
+++ b/resource-definitions/ingress/alb/README.md
@@ -1,0 +1,5 @@
+## Using the Amazon Load Balancer
+
+This section contains example Resource Definitions using the [Amazon Application Load Balancer (ALB)](https://aws.amazon.com/elasticloadbalancing/application-load-balancer/) for handling Kubernetes ingress traffic.
+
+* [ingress-alb.tf](ingress-alb.tf): defines an `Ingress` annotated for an internet-facing ALB. This format is for use with the [Humanitec Terraform Provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/ingress/alb/ingress-alb.tf
+++ b/resource-definitions/ingress/alb/ingress-alb.tf
@@ -1,0 +1,27 @@
+# This Resource Definition provisions an Ingress object for the Amazon Application Load Balancer (ALB)
+
+variable "ingress_resource_name" {}
+variable "ingress_group_name" {}
+variable "ingress_cert_arn" {}
+
+resource "humanitec_resource_definition" "ingress" {
+  id          = var.ingress_resource_name
+  name        = var.ingress_resource_name
+  type        = "ingress"
+  driver_type = "humanitec/ingress"
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "annotations" : jsonencode({
+        "alb.ingress.kubernetes.io/certificate-arn" : "${var.ingress_cert_arn}",
+        "alb.ingress.kubernetes.io/group.name" : "${var.ingress_group_name}",
+        "alb.ingress.kubernetes.io/listen-ports" : "[{\"HTTP\":80},{\"HTTPS\":443}]",
+        "alb.ingress.kubernetes.io/scheme" : "internet-facing",
+        "alb.ingress.kubernetes.io/ssl-redirect" : "443",
+        "alb.ingress.kubernetes.io/target-type" : "ip"
+      }),
+      "class" : "alb",
+      "no_tls" : true
+    })
+  }
+}

--- a/resource-definitions/ingress/kong/README.md
+++ b/resource-definitions/ingress/kong/README.md
@@ -1,0 +1,5 @@
+## Using the Kong Ingress Controller
+
+This section contains example Resource Definitions using the [Kong Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller) for handling Kubernetes ingress traffic.
+
+* [ingress-kong.yaml](ingress-kong.yaml): defines an `Ingress` object annotated for Kong. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)

--- a/resource-definitions/ingress/kong/ingress-kong.yaml
+++ b/resource-definitions/ingress/kong/ingress-kong.yaml
@@ -1,0 +1,16 @@
+# This Resource Definition provisions an Ingress object for the Kong Ingress Controller
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: kong-ingress
+entity:
+  name: kong-ingress
+  type: ingress
+  driver_type: humanitec/ingress
+  driver_inputs:
+    values:
+      annotations:
+        konghq.com/preserve-host: "false"
+        konghq.com/strip-path: "true"
+      api_version: v1
+      class: kong

--- a/resource-definitions/ingress/openshift/README.md
+++ b/resource-definitions/ingress/openshift/README.md
@@ -1,0 +1,5 @@
+## Using the OpenShift Ingress Operator
+
+This section contains example Resource Definitions using the [OpenShift Container Platform Ingress Operator](https://docs.openshift.com/container-platform/latest/networking/ingress-operator.html) for handling Kubernetes ingress traffic.
+
+* [ingress-openshift-operator.yaml](ingress-openshift-operator.yaml): defines an `Ingress` object annotated for the OpenShift Ingress Operator. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)

--- a/resource-definitions/ingress/openshift/ingress-openshift-operator.yaml
+++ b/resource-definitions/ingress/openshift/ingress-openshift-operator.yaml
@@ -1,0 +1,12 @@
+# This Resource Definition provisions an Ingress object for the OpenShift Container Platform Ingress Operator
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: openshift-ingress
+entity:
+  name: openshift-ingress
+  type: ingress
+  driver_type: humanitec/ingress
+  driver_inputs:
+    values:
+      class: openshift-default


### PR DESCRIPTION
This PR adds example Resource Definitions for creating [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) objects using the [Ingress](https://developer.humanitec.com/integration-and-extensions/drivers/k8-drivers/ingress/) Driver.