### PR TITLE
add missing apiversion and kind

### DIFF
--- a/score/multiple-workloads/deploy-config.yaml
+++ b/score/multiple-workloads/deploy-config.yaml
@@ -1,3 +1,5 @@
+apiVersion: config.humanitec.io/v1b1
+kind: ScoreDeployConfig
 workloads:
   - name: example-service
     specFile: ./score.example-service.yaml


### PR DESCRIPTION
The example is missing the apiVersion and kind for the deployment config.