### PR TITLE
fix: update extensions file to specify container resources

### DIFF
--- a/score/multiple-workloads/score.humanitec.yaml
+++ b/score/multiple-workloads/score.humanitec.yaml
@@ -1,6 +1,8 @@
 apiVersion: humanitec.org/v1b1
 spec:
-  resources:
-    limits:
-      cpu: "500m"
-      memory: "256Mi"
+  containers:
+    demo:
+      resources:
+        limits:
+          cpu: "500m"
+          memory: "256Mi"


### PR DESCRIPTION
The resources must be specified at container level. Here both workloads have the same container name ("demo") so we can use the same extensions file, but in other cases you'd need to use an extensions file specific to the workload.

cc @Nilsty who noticed this.