### PR TITLE
Renaming "dynamic" to "temporary" credentials

### DIFF
--- a/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
+++ b/resource-definitions/k8s-cluster-aks/agent/aks-agent.tf
@@ -3,7 +3,7 @@ resource "humanitec_resource_definition" "aks-agent" {
   id             = "aks-agent"
   name           = "aks-agent"
   type           = "k8s-cluster"
-  driver_account = "azure-dynamic-creds"
+  driver_account = "azure-temporary"
   driver_inputs = {
     values_string = jsonencode({
       "loadbalancer"    = "20.10.10.10"

--- a/resource-definitions/k8s-cluster-aks/agent/aks-agent.yaml
+++ b/resource-definitions/k8s-cluster-aks/agent/aks-agent.yaml
@@ -8,7 +8,7 @@ entity:
   name: aks-agent
   type: k8s-cluster
   # The driver_account is referring to a Cloud Account configured in your Organization
-  driver_account: azure-dynamic-creds
+  driver_account: azure-temporary
   driver_type: humanitec/k8s-cluster-aks
   driver_inputs:
     secrets:

--- a/resource-definitions/k8s-cluster-aks/credentials/README.md
+++ b/resource-definitions/k8s-cluster-aks/credentials/README.md
@@ -7,9 +7,9 @@ This section contains example Resource Definitions using static credentials for 
 * [aks-static-credentials.yaml](aks-static-credentials.yaml): use static credentials of a service principal defined via environment variables. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
 * [aks-static-credentials-cloudaccount.yaml](aks-static-credentials-cloudaccount.yaml): use static credentials defined via a [Cloud Account](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/). This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
 
-## Using dynamic credentials
+## Using temporary credentials
 
-This section contains example Resource Definitions using [dynamic credentials](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/azure/#azure-workload-identity-federation) for connecting to AKS clusters.
+This section contains example Resource Definitions using [temporary credentials](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/azure/#azure-workload-identity-federation) for connecting to AKS clusters.
 
-* [aks-dynamic-credentials.yaml](aks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
-* [aks-dynamic-credentials.tf](aks-dynamic-credentials.tf): uses dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)
+* [aks-temporary-credentials.yaml](aks-temporary-credentials.yaml): use temporary credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
+* [aks-temporary-credentials.tf](aks-temporary-credentials.tf): uses temporary credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-aks/credentials/aks-temporary-credentials.tf
+++ b/resource-definitions/k8s-cluster-aks/credentials/aks-temporary-credentials.tf
@@ -1,9 +1,9 @@
-resource "humanitec_resource_definition" "aks-dynamic-credentials" {
+resource "humanitec_resource_definition" "aks-temporary-credentials" {
   driver_type    = "humanitec/k8s-cluster-aks"
-  id             = "aks-dynamic-credentials"
-  name           = "aks-dynamic-credentials"
+  id             = "aks-temporary-credentials"
+  name           = "aks-temporary-credentials"
   type           = "k8s-cluster"
-  driver_account = "azure-dynamic-creds"
+  driver_account = "azure-temporary-creds"
   driver_inputs = {
     values_string = jsonencode({
       "loadbalancer"    = "20.10.10.10"

--- a/resource-definitions/k8s-cluster-aks/credentials/aks-temporary-credentials.yaml
+++ b/resource-definitions/k8s-cluster-aks/credentials/aks-temporary-credentials.yaml
@@ -1,14 +1,14 @@
-# Connect to an AKS cluster using dynamic credentials defined via a Cloud Account
+# Connect to an AKS cluster using temporary credentials defined via a Cloud Account
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: aks-dynamic-credentials
+  id: aks-temporary-credentials
 entity:
-  name: aks-dynamic-credentials
+  name: aks-temporary-credentials
   type: k8s-cluster
   # The driver_account references a Cloud Account of type "azure-identity"
   # which needs to be configured for your Organization.
-  driver_account: azure-dynamic-creds
+  driver_account: azure-temporary-creds
   driver_type: humanitec/k8s-cluster-aks
   driver_inputs:
     values:

--- a/resource-definitions/k8s-cluster-eks/agent/eks-agent.yaml
+++ b/resource-definitions/k8s-cluster-eks/agent/eks-agent.yaml
@@ -1,5 +1,5 @@
 # EKS private cluster. It is to be accessed via the Humanitec Agent
-# It is using a Cloud Account with dynamic credentials
+# It is using a Cloud Account with temporary credentials
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:

--- a/resource-definitions/k8s-cluster-eks/credentials/README.md
+++ b/resource-definitions/k8s-cluster-eks/credentials/README.md
@@ -7,9 +7,9 @@ This section contains example Resource Definitions using static credentials for 
 * [eks-static-credentials.yaml](eks-static-credentials.yaml): use static credentials defined via environment variables. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
 * [eks-static-credentials-cloudaccount.yaml](eks-static-credentials-cloudaccount.yaml): use static credentials defined via a [Cloud Account](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/). This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
 
-## Using dynamic credentials
+## Using temporary credentials
 
-This section contains example Resource Definitions using dynamic credentials for connecting to EKS clusters.
+This section contains example Resource Definitions using temporary credentials for connecting to EKS clusters.
 
-* [eks-dynamic-credentials.yaml](eks-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
-* [eks-dynamic-credentials.tf](eks-dynamic-credentials.tf): uses dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)
+* [eks-temporary-credentials.yaml](eks-temporary-credentials.yaml): use temporary credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
+* [eks-temporary-credentials.tf](eks-temporary-credentials.tf): uses temporary credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-eks/credentials/eks-temporary-credentials.tf
+++ b/resource-definitions/k8s-cluster-eks/credentials/eks-temporary-credentials.tf
@@ -1,7 +1,7 @@
-resource "humanitec_resource_definition" "eks-dynamic-credentials" {
+resource "humanitec_resource_definition" "eks-temporary-credentials" {
   driver_type    = "humanitec/k8s-cluster-eks"
-  id             = "eks-dynamic-credentials"
-  name           = "eks-dynamic-credentials"
+  id             = "eks-temporary-credentials"
+  name           = "eks-temporary-credentials"
   type           = "k8s-cluster"
   driver_account = "aws-temp-creds"
   driver_inputs = {

--- a/resource-definitions/k8s-cluster-eks/credentials/eks-temporary-credentials.yaml
+++ b/resource-definitions/k8s-cluster-eks/credentials/eks-temporary-credentials.yaml
@@ -1,15 +1,15 @@
-# Connect to an EKS cluster using dynamic credentials defined via a Cloud Account
+# Connect to an EKS cluster using temporary credentials defined via a Cloud Account
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: eks-dynamic-credentials
+  id: eks-temporary-credentials
 entity:
-  name: eks-dynamic-credentials
+  name: eks-temporary-credentials
   type: k8s-cluster
   # The driver_account references a Cloud Account of type "aws-role"
   # which needs to be configured for your Organization.
   driver_account: aws-temp-creds
-  # The driver_type k8s-cluster-eks automatically handles the dynamic credentials
+  # The driver_type k8s-cluster-eks automatically handles the temporary credentials
   # injected via the driver_account.
   driver_type: humanitec/k8s-cluster-eks
   driver_inputs:

--- a/resource-definitions/k8s-cluster-gke/agent/gke-agent.tf
+++ b/resource-definitions/k8s-cluster-gke/agent/gke-agent.tf
@@ -3,7 +3,7 @@ resource "humanitec_resource_definition" "gke-agent" {
   id             = "gke-agent"
   name           = "gke-agent"
   type           = "k8s-cluster"
-  driver_account = "gcp-dynamic-creds"
+  driver_account = "gcp-temporary-creds"
   driver_inputs = {
     values_string = jsonencode({
       "loadbalancer" = "35.10.10.10"

--- a/resource-definitions/k8s-cluster-gke/agent/gke-agent.yaml
+++ b/resource-definitions/k8s-cluster-gke/agent/gke-agent.yaml
@@ -1,5 +1,5 @@
 # GKE private cluster. It is to be accessed via the Humanitec Agent
-# It is using a Cloud Account with dynamic credentials
+# It is using a Cloud Account with temporary credentials
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
@@ -8,7 +8,7 @@ entity:
   name: gke-agent
   type: k8s-cluster
   # The driver_account is referring to a Cloud Account configured in your Organization
-  driver_account: gcp-dynamic-creds
+  driver_account: gcp-temporary-creds
   driver_type: humanitec/k8s-cluster-gke
   driver_inputs:
     secrets:

--- a/resource-definitions/k8s-cluster-gke/credentials/README.md
+++ b/resource-definitions/k8s-cluster-gke/credentials/README.md
@@ -7,9 +7,9 @@ This section contains example Resource Definitions using static credentials for 
 * [gke-static-credentials.yaml](gke-static-credentials.yaml): use static credentials defined via environment variables. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
 * [gke-static-credentials-cloudaccount.yaml](gke-static-credentials-cloudaccount.yaml): use static credentials defined via a [Cloud Account](https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/). This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/).
 
-## Using dynamic credentials
+## Using temporary credentials
 
-This section contains example Resource Definitions using dynamic credentials for connecting to GKE clusters.
+This section contains example Resource Definitions using temporary credentials for connecting to GKE clusters.
 
-* [gke-dynamic-credentials.yaml](gke-dynamic-credentials.yaml): use dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
-* [gke-dynamic-credentials.tf](gke-dynamic-credentials.tf): uses dynamic credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)
+* [gke-temporary-credentials.yaml](gke-temporary-credentials.yaml): use temporary credentials defined via a Cloud Account. This format is for use with the [Humanitec CLI](https://developer.humanitec.com/platform-orchestrator/cli/)
+* [gke-temporary-credentials.tf](gke-temporary-credentials.tf): uses temporary credentials defined via a Cloud Account. This format is for use with the [Humanitec Terraform provider](https://registry.terraform.io/providers/humanitec/humanitec)

--- a/resource-definitions/k8s-cluster-gke/credentials/gke-temporary-credentials.tf
+++ b/resource-definitions/k8s-cluster-gke/credentials/gke-temporary-credentials.tf
@@ -1,9 +1,9 @@
-resource "humanitec_resource_definition" "gke-dynamic-credentials" {
+resource "humanitec_resource_definition" "gke-temporary-credentials" {
   driver_type    = "humanitec/k8s-cluster-gke"
-  id             = "gke-dynamic-credentials"
-  name           = "gke-dynamic-credentials"
+  id             = "gke-temporary-credentials"
+  name           = "gke-temporary-credentials"
   type           = "k8s-cluster"
-  driver_account = "gcp-dynamic-creds"
+  driver_account = "gcp-temporary-creds"
   driver_inputs = {
     values_string = jsonencode({
       "loadbalancer" = "35.10.10.10"

--- a/resource-definitions/k8s-cluster-gke/credentials/gke-temporary-credentials.yaml
+++ b/resource-definitions/k8s-cluster-gke/credentials/gke-temporary-credentials.yaml
@@ -1,14 +1,14 @@
-# Connect to a GKE cluster using dynamic credentials defined via a Cloud Account
+# Connect to a GKE cluster using temporary credentials defined via a Cloud Account
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: gke-dynamic-credentials
+  id: gke-temporary-credentials
 entity:
-  name: gke-dynamic-credentials
+  name: gke-temporary-credentials
   type: k8s-cluster
   # The driver_account references a Cloud Account of type "gcp-identity"
   # which needs to be configured for your Organization.
-  driver_account: gcp-dynamic-creds
+  driver_account: gcp-temporary-creds
   driver_type: humanitec/k8s-cluster-gke
   driver_inputs:
     values:

--- a/resource-definitions/terraform-driver/credentials/README.md
+++ b/resource-definitions/terraform-driver/credentials/README.md
@@ -24,18 +24,18 @@ In this set of examples, we provide two `config` Resource Definitions for AWS an
 - [Account config (`account-config-gcp.yaml`)](./account-config-gcp.yaml)
 - [File Credentials (`gcp-file-credentials.yaml`)](./gcp-file-credentials.yaml)
 
-## Dynamic credentials
+## Temporary credentials
 
-Using a Cloud Account type that supports dynamic credentials, those credentials can be easily injected into a Resource Definition using the Terraform Driver. Use a `driver_account` referencing the Cloud Account in the Resource Definition, and access its the credentials through the supplied values as shown in the examples.
+Using a Cloud Account type that supports temporary credentials, those credentials can be easily injected into a Resource Definition using the Terraform Driver. Use a `driver_account` referencing the Cloud Account in the Resource Definition, and access its the credentials through the supplied values as shown in the examples.
 
 ### AWS
 
-- [S3 bucket (`s3-dynamic-credentials.yaml`)](./s3-dynamic-credentials.yaml)
+- [S3 bucket (`s3-temporary-credentials.yaml`)](./s3-temporary-credentials.yaml)
 
 ### GCP
 
-- [Cloud Storage bucket (`gcs-dynamic-credentials.yaml`)](./gcs-dynamic-credentials.yaml)
+- [Cloud Storage bucket (`gcs-temporary-credentials.yaml`)](./gcs-temporary-credentials.yaml)
 
 ### Azure
 
-- [Blob Storage container (`azure-blob-storage-dynamic-credentials.yaml`)](./azure-blob-storage-dynamic-credentials.yaml)
+- [Blob Storage container (`azure-blob-storage-temporary-credentials.yaml`)](./azure-blob-storage-temporary-credentials.yaml)

--- a/resource-definitions/terraform-driver/credentials/azure-blob-storage-temporary-credentials.tf
+++ b/resource-definitions/terraform-driver/credentials/azure-blob-storage-temporary-credentials.tf
@@ -1,9 +1,9 @@
-resource "humanitec_resource_definition" "blob-storage-dynamic-credentials" {
+resource "humanitec_resource_definition" "blob-storage-temporary-credentials" {
   driver_type    = "humanitec/terraform"
-  id             = "blob-storage-dynamic-credentials"
-  name           = "blob-storage-dynamic-credentials"
+  id             = "blob-storage-temporary-credentials"
+  name           = "blob-storage-temporary-credentials"
   type           = "azure-blob"
-  driver_account = "azure-dynamic-creds"
+  driver_account = "azure-temporary-creds"
   driver_inputs = {
     values_string = jsonencode({
       "variables" = {

--- a/resource-definitions/terraform-driver/credentials/azure-blob-storage-temporary-credentials.yaml
+++ b/resource-definitions/terraform-driver/credentials/azure-blob-storage-temporary-credentials.yaml
@@ -1,15 +1,15 @@
-# Create Azure Blob Storage container using dynamic credentials defined via a Cloud Account
+# Create Azure Blob Storage container using temporary credentials defined via a Cloud Account
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: blob-storage-dynamic-credentials
+  id: blob-storage-temporary-credentials
 entity:
-  name: blob-storage-dynamic-credentials
+  name: blob-storage-temporary-credentials
   type: azure-blob
   driver_type: humanitec/terraform
   # The driver_account references a Cloud Account of type "azure-identity"
   # which needs to be configured for your Organization.
-  driver_account: azure-dynamic-creds
+  driver_account: azure-temporary-creds
   driver_inputs:
     values:
       variables:

--- a/resource-definitions/terraform-driver/credentials/gcs-temporary-credentials.tf
+++ b/resource-definitions/terraform-driver/credentials/gcs-temporary-credentials.tf
@@ -1,9 +1,9 @@
-resource "humanitec_resource_definition" "gcs-dynamic-credentials" {
+resource "humanitec_resource_definition" "gcs-temporary-credentials" {
   driver_type    = "humanitec/terraform"
-  id             = "gcs-dynamic-credentials"
-  name           = "gcs-dynamic-credentials"
+  id             = "gcs-temporary-credentials"
+  name           = "gcs-temporary-credentials"
   type           = "gcs"
-  driver_account = "gcp-dynamic-creds"
+  driver_account = "gcp-temporary-creds"
   driver_inputs = {
     values_string = jsonencode({
       "variables" = {

--- a/resource-definitions/terraform-driver/credentials/gcs-temporary-credentials.yaml
+++ b/resource-definitions/terraform-driver/credentials/gcs-temporary-credentials.yaml
@@ -1,15 +1,15 @@
-# Create Google Cloud Storage bucket using dynamic credentials defined via a Cloud Account
+# Create Google Cloud Storage bucket using temporary credentials defined via a Cloud Account
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: gcs-dynamic-credentials
+  id: gcs-temporary-credentials
 entity:
-  name: gcs-dynamic-credentials
+  name: gcs-temporary-credentials
   type: gcs
   driver_type: humanitec/terraform
   # The driver_account references a Cloud Account of type "gcp-identity"
   # which needs to be configured for your Organization.
-  driver_account: gcp-dynamic-creds
+  driver_account: gcp-temporary-creds
   driver_inputs:
     values:
       variables:

--- a/resource-definitions/terraform-driver/credentials/s3-temporary-credentials.tf
+++ b/resource-definitions/terraform-driver/credentials/s3-temporary-credentials.tf
@@ -1,7 +1,7 @@
-resource "humanitec_resource_definition" "s3-dynamic-credentials" {
+resource "humanitec_resource_definition" "s3-temporary-credentials" {
   driver_type    = "humanitec/terraform"
-  id             = "s3-dynamic-credentials"
-  name           = "s3-dynamic-credentials"
+  id             = "s3-temporary-credentials"
+  name           = "s3-temporary-credentials"
   type           = "s3"
   driver_account = "aws-temp-creds"
   driver_inputs = {

--- a/resource-definitions/terraform-driver/credentials/s3-temporary-credentials.yaml
+++ b/resource-definitions/terraform-driver/credentials/s3-temporary-credentials.yaml
@@ -1,10 +1,10 @@
-# Create S3 bucket using dynamic credentials defined via a Cloud Account
+# Create S3 bucket using temporary credentials defined via a Cloud Account
 apiVersion: entity.humanitec.io/v1b1
 kind: Definition
 metadata:
-  id: s3-dynamic-credentials
+  id: s3-temporary-credentials
 entity:
-  name: s3-dynamic-credentials
+  name: s3-temporary-credentials
   type: s3
   driver_type: humanitec/terraform
   # The driver_account references a Cloud Account of type "aws-role"


### PR DESCRIPTION
This PR renames all occurrences of "dynamic credentials" to "temporary credentials" to align with current terminology.

Applying the same renaming to the developer docs will be a subsequent step following the integration of these updated examples.