### PR TITLE
Add ResourceQuota example

### DIFF
--- a/.github/workflows/scheduled-generated.yml
+++ b/.github/workflows/scheduled-generated.yml
@@ -1,7 +1,7 @@
 name: Update generated content
 on:
   schedule:
-    - cron: "0 10 * * 1-5"
+    - cron: "0 9 * * 1-5"
   workflow_dispatch:
   # push: # uncomment to test this workflow
 jobs:

--- a/resource-definitions/template-driver/resourcequota/README.md
+++ b/resource-definitions/template-driver/resourcequota/README.md
@@ -1,0 +1,27 @@
+This example shows a sample usage of the `base-env` Resource Type. It is one of the _implicit_ [Resource Types](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/) that always gets provisioned for a Deployment.
+
+The Resource Definition [base-env-resourcequota.yaml](./base-env-resourcequota.yaml) uses it the provision a Kubernetes manifest describing a [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) in the target namespace.
+
+The `base-env` Resource Definition reads the configuration values from another Resource of type `config` using a [Resource Reference](https://developer.humanitec.com/platform-orchestrator/resources/resource-graph/#resource-references). The reference specifies a class (`config#quota`) so that the proper `config` Resource Definition will be matched based on its matching criteria.
+
+Two `config` Resource Definitions are provided:
+
+- [config-quota.yaml](config-quota.yaml) will be matched for all references of `res_id: quota`
+- [config-quota-override.yaml](config-quota-override.yaml) will additionally be matched for a particular `app_id: my-app` only, effectively providing an override for the configuration values for this particular Application id
+
+```mermaid
+flowchart LR
+    subgraph app2[Resource Graph &quot;my-app&quot;]
+        direction LR
+        workload2[Workload] --> baseEnv2(type: base-env\nid: base-env) --> config2("type: config\nid:quota")
+    end
+    subgraph app1[Resource Graph &quot;some-app&quot;]
+        direction LR
+        workload1[Workload] --> baseEnv1(type: base-env\nid: base-env) --> config1("type: config\nid: quota")
+    end
+    resDefBaseEnv[base-env\nResource Definition]
+    resDefBaseEnv -.-> baseEnv1
+    resDefBaseEnv -.-> baseEnv2
+    resDefQuotaConfig[config-quota\nResource Definition] -.->|criteria:\n- res_id: quota| config1
+    resDefQuotaConfigOverride[config-quota-override\nResource Definition] -.->|criteria:\n- res_id: quota\n&nbsp;&nbsp;app_id: my-app| config2
+```

--- a/resource-definitions/template-driver/resourcequota/README.md
+++ b/resource-definitions/template-driver/resourcequota/README.md
@@ -9,6 +9,8 @@ Two `config` Resource Definitions are provided:
 - [config-quota.yaml](config-quota.yaml) will be matched for all references of `res_id: quota`
 - [config-quota-override.yaml](config-quota-override.yaml) will additionally be matched for a particular `app_id: my-app` only, effectively providing an override for the configuration values for this particular Application id
 
+The Resource Graphs for two Applications, one of which matches the "override" criteria, will look like this:
+
 ```mermaid
 flowchart LR
     subgraph app2[Resource Graph &quot;my-app&quot;]

--- a/resource-definitions/template-driver/resourcequota/base-env-resourcequota.yaml
+++ b/resource-definitions/template-driver/resourcequota/base-env-resourcequota.yaml
@@ -1,0 +1,28 @@
+# This Resource Definition uses the base-env Resource type to create
+# a ResourceQuota manifest in the target namespace.
+# The actual values are read from a referenced config resource.
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: base-env
+entity:
+  name: base-env
+  type: base-env
+  driver_type: humanitec/template
+  driver_inputs:
+    values:
+      templates:
+        manifests: |-
+          quota.yaml:
+            location: namespace
+            data:
+              apiVersion: v1
+              kind: ResourceQuota
+              metadata:
+                name: compute-resources
+              spec:
+                hard:
+                  limits.cpu: ${resources['config#quota'].outputs.limits-cpu}
+                  limits.memory: ${resources['config#quota'].outputs.limits-memory}
+  criteria:
+  - {}

--- a/resource-definitions/template-driver/resourcequota/config-quota-override.yaml
+++ b/resource-definitions/template-driver/resourcequota/config-quota-override.yaml
@@ -1,0 +1,18 @@
+# This Resource Definition uses the Echo Driver to provide configuration values
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: quota-config-override
+entity:
+  name: quota-config-override
+  type: config
+  driver_type: humanitec/echo
+  driver_inputs:
+    # Any Driver inputs will be returned as outputs by the Echo Driver
+    values:
+      limits-cpu: "750m"
+      limits-memory: "750Mi"
+  # The matching criteria make this Resource Definition match for a particular app_id only
+  criteria:
+  - res_id: quota
+    app_id: my-app

--- a/resource-definitions/template-driver/resourcequota/config-quota.yaml
+++ b/resource-definitions/template-driver/resourcequota/config-quota.yaml
@@ -1,0 +1,16 @@
+# This Resource Definition uses the Echo Driver to provide configuration values
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: quota-config
+entity:
+  name: quota-config
+  type: config
+  driver_type: humanitec/echo
+  driver_inputs:
+    # Any Driver inputs will be returned as outputs by the Echo Driver
+    values:
+      limits-cpu: "500m"
+      limits-memory: "500Mi"
+  criteria:
+  - res_id: quota


### PR DESCRIPTION
This PR adds a Resource Definition example showing how to use a `base-env` to provision a Kubernetes `ResourceQuota` manifest.

The example is categorized as a Template Driver one because the core Resource Definition uses that Driver.

Unrelated, but living up to the occasion, it also prepones the auto-generation workflow so that it runs one hour earlier than the corresponding workflow in the developer-docs. This way changes to examples can potentially be integrated within one day.