### PR TITLE
fix: rev -> branch in git examples

### DIFF
--- a/resource-definitions/terraform-driver/private-git-repo/https-secret-refs.tf
+++ b/resource-definitions/terraform-driver/private-git-repo/https-secret-refs.tf
@@ -25,9 +25,9 @@ resource "humanitec_resource_definition" "example-resource" {
     values_string = jsonencode({
       # Connection information to the target Git repo
       source = {
-        path = "some-resource-type/terraform"
-        branch  = "refs/heads/main"
-        url  = "https://my-domain.com/my-org/my-repo.git"
+        path   = "some-resource-type/terraform"
+        branch = "refs/heads/main"
+        url    = "https://my-domain.com/my-org/my-repo.git"
       }
       # ...
     })

--- a/resource-definitions/terraform-driver/private-git-repo/https-secret-refs.tf
+++ b/resource-definitions/terraform-driver/private-git-repo/https-secret-refs.tf
@@ -26,7 +26,7 @@ resource "humanitec_resource_definition" "example-resource" {
       # Connection information to the target Git repo
       source = {
         path = "some-resource-type/terraform"
-        rev  = "refs/heads/main"
+        branch  = "refs/heads/main"
         url  = "https://my-domain.com/my-org/my-repo.git"
       }
       # ...

--- a/resource-definitions/terraform-driver/private-git-repo/ssh-secret-refs.tf
+++ b/resource-definitions/terraform-driver/private-git-repo/ssh-secret-refs.tf
@@ -25,9 +25,9 @@ resource "humanitec_resource_definition" "example-resource" {
     values_string = jsonencode({
       # Connection information to the target Git repo
       source = {
-        path = "some-resource-type/terraform"
-        rev  = "refs/heads/main"
-        url  = "git@my-domain.com:my-org/my-repo.git"
+        path    = "some-resource-type/terraform"
+        branch  = "refs/heads/main"
+        url     = "git@my-domain.com:my-org/my-repo.git"
       }
       # ...
     })


### PR DESCRIPTION
Noticed this while checking over our documentation on the git cluster type. rev should be "branch".