### PR TITLE
Removing unnecessary Score class

### DIFF
--- a/resource-graph-patterns/break-a-loop-additional-resource/score.yaml
+++ b/resource-graph-patterns/break-a-loop-additional-resource/score.yaml
@@ -22,5 +22,3 @@ containers:
 resources:
   my-s3:
     type: s3
-    # Change the class to "two" 
-    class: one


### PR DESCRIPTION
The Score class request is not required in this example. It is probably a copy & paste leftover from the "Propagate class" example.