### PR TITLE
Add Score example on Shared Resources

### DIFF
--- a/score/shared-resource/README.md
+++ b/score/shared-resource/README.md
@@ -4,9 +4,9 @@ Workloads using the Shared Resource will then reference the same node in the Res
 
 ### Example: Shared DNS
 
-This example shows a frontend and a backend workload. Both are exposed via DNS. The frontend is exposed via an external DNS, and it needs to access the backend via it associated DNS name as well. It therefore requires the backend DNS name to be injected as an environment variable.
+This example shows a frontend and a backend Workload. Both are exposed via DNS. The frontend is exposed via an external DNS, and it needs to access the backend via it associated DNS name as well. It therefore requires the backend DNS name to be injected as an environment variable.
 
-To achieve this, the backend `dns` is made a Shared Resource by assigning it an `id` in the Score files. Both Score files need to use the same `id` to reference the same Resource.
+To achieve this, the backend `dns` is made a Shared Resource by assigning it an `id` in Score. Both Score files need to use the same `id` to reference the same Resource.
 
 Note that the Workloads refer to the Shared Resource using a different resource name (`api-dns` vs. `my-dns`). That name is local to the Score file and may be different.
 

--- a/score/shared-resource/README.md
+++ b/score/shared-resource/README.md
@@ -1,0 +1,32 @@
+When several Workloads need to use the same real-world Resource, this can be modelled as a [Shared Resource](https://developer.humanitec.com/platform-orchestrator/resources/dependent-resources/#shared-resources-in-score).
+
+Workloads using the Shared Resource will then reference the same node in the Resource Graph.
+
+### Example: Shared DNS
+
+This example shows a frontend and a backend workload. Both are exposed via DNS. The frontend is exposed via an external DNS, and it needs to access the backend via it associated DNS name as well. It therefore requires the backend DNS name to be injected as an environment variable.
+
+To achieve this, the backend `dns` is made a Shared Resource by assigning it an `id` in the Score files. Both Score files need to use the same `id` to reference the same Resource.
+
+Note that the Workloads refer to the Shared Resource using a different resource name (`api-dns` vs. `my-dns`). That name is local to the Score file and may be different.
+
+The frontend has an additional `dns` for its own reachability. All `dns` resources are used in conjunction with a `route`.
+
+The respective portions of the Resource Graph will then look like this:
+
+```mermaid
+---
+title: Resource Graph
+---
+flowchart LR
+    frontend(frontend) --> fe-route(route) --> fe-dns(dns)
+    frontend --> fe-dns
+    backend(backend) --> be-route(route) --> be-dns(dns)
+    frontend ---> be-dns
+    backend --> be-dns
+```
+
+Example files:
+
+- [`score-frontend.yaml`](score-frontend.yaml): Score file for the frontend Workload
+- [`score-backend.yaml`](score-backend.yaml): Score file for the backend Workload

--- a/score/shared-resource/score-backend.yaml
+++ b/score/shared-resource/score-backend.yaml
@@ -1,0 +1,21 @@
+# Example Score file for a Workload using a Shared Resource to provide its DNS name to another Workload
+apiVersion: score.dev/v1b1
+metadata:
+  name: shared-resource-example-backend
+
+containers:
+  backend:
+    image: my-be-service:latest
+
+resources:
+  # This resource becomes a Shared Resource by assiging it an "id"
+  # Other Workloads using the same id will reference the same resource
+  my-dns:
+    type: dns
+    id: external-dns
+  my-route:
+    type: route
+    params:
+      host: ${resources.my-dns.host}
+      path: /
+      port: 8765

--- a/score/shared-resource/score-backend.yaml
+++ b/score/shared-resource/score-backend.yaml
@@ -12,7 +12,7 @@ resources:
   # Other Workloads using the same id will reference the same resource
   my-dns:
     type: dns
-    id: external-dns
+    id: backend-dns
   my-route:
     type: route
     params:

--- a/score/shared-resource/score-frontend.yaml
+++ b/score/shared-resource/score-frontend.yaml
@@ -1,0 +1,25 @@
+# Example Score file for a Workload using a Shared Resource to obtain the DNS name of another Workload
+apiVersion: score.dev/v1b1
+metadata:
+  name: shared-resource-example-frontend
+
+containers:
+  frontend:
+    image: my-fe-service:latest
+    variables:
+      # Inject the DNS name of the backend service as an environment variable
+      API_URL: https://${resources.api-dns.host}
+
+resources:
+  # This resource becomes a Shared Resource by assiging it an "id"
+  # Other Workloads using the same id will reference the same resource
+  api-dns:
+    type: dns
+    id: external-dns
+  fe-dns:
+    type: dns
+  fe-route:
+    type: route
+    host: ${resources.fe-dns.host}
+      path: /
+      port: 80

--- a/score/shared-resource/score-frontend.yaml
+++ b/score/shared-resource/score-frontend.yaml
@@ -15,7 +15,7 @@ resources:
   # Other Workloads using the same id will reference the same resource
   api-dns:
     type: dns
-    id: external-dns
+    id: backend-dns
   fe-dns:
     type: dns
   fe-route:


### PR DESCRIPTION
This PR adds a Score example on Shared Resources using the real-world scenario of a frontend Workload requiring the DNS name of a backend Workload.