### PR TITLE
Provide Terraform support in runner

### DIFF
--- a/.github/workflows/scheduled-generated.yml
+++ b/.github/workflows/scheduled-generated.yml
@@ -3,12 +3,12 @@ on:
   schedule:
     - cron: "0 9 * * 1-5"
   workflow_dispatch:
-  # push: # uncomment to test this workflow
+  push: # uncomment to test this workflow
 jobs:
   update:
-    # Pinning the runner to a version supporting Terraform
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
+      - uses: hashicorp/setup-terraform@v3
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/scheduled-generated.yml
+++ b/.github/workflows/scheduled-generated.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: "0 9 * * 1-5"
   workflow_dispatch:
-  push: # uncomment to test this workflow
+  # push: # uncomment to test this workflow
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-generated.yml
+++ b/.github/workflows/scheduled-generated.yml
@@ -6,7 +6,8 @@ on:
   # push: # uncomment to test this workflow
 jobs:
   update:
-    runs-on: ubuntu-latest
+    # Pinning the runner to a version supporting Terraform
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR installs Terraform on the GitHub runner to continue being able to run `terraform fmt` in the  `.github/workflows/scheduled-generated.yml` workflow.

## Background

The GitHub runner image `ubuntu:latest`, now being `ubuntu-24.04`, used in the workflow does not include the `terraform` tool any longer, causing that workflow to [fail](https://github.com/humanitec-architecture/example-library/actions/runs/11271010863/job/31342980176#step:5:5).

GitHub announcement: https://github.com/actions/runner-images/issues/10636

Installed software of `ubuntu-22.02`, the previous `ubuntu-latest`: https://github.com/actions/runner-images/blob/ubuntu22/20240922.1/images/ubuntu/Ubuntu2204-Readme.md

Installed software of `ubuntu-24.02`, the current `ubuntu-latest`: https://github.com/actions/runner-images/blob/ubuntu22/20240922.1/images/ubuntu/Ubuntu2404-Readme.md