### PR TITLE
Fix params in shared resource Score file

### DIFF
--- a/score/shared-resource/score-frontend.yaml
+++ b/score/shared-resource/score-frontend.yaml
@@ -20,6 +20,7 @@ resources:
     type: dns
   fe-route:
     type: route
-    host: ${resources.fe-dns.host}
+    params:
+      host: ${resources.fe-dns.host}
       path: /
       port: 80


### PR DESCRIPTION
This PR fixes a faulty `params` section in one of the Score files for the "shared resources" example.