### PR TITLE
Improve imagePullSecrets example description

### DIFF
--- a/resource-definitions/template-driver/imagepullsecrets/README.md
+++ b/resource-definitions/template-driver/imagepullsecrets/README.md
@@ -2,7 +2,7 @@ This section shows how to use the [Template Driver](https://developer.humanitec.
 
 The example implements the Kubernetes standard mechanism to [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). It creates a Kubernetes Secret of `kubernetes.io/dockerconfigjson` type, reading the credentials from a secret store. It then configures the secret as the `imagePullSecret` for a Workload's Pod.
 
-The example is applicable only when using the [Humanitec Operator](https://developer.humanitec.com/integration-and-extensions/humanitec-operator/overview/) on the cluster. With the Operator, using the [Registries](https://developer.humanitec.com/integration-and-extensions/ci-cd/integrate/#container-registries) feature of the Platform Orchestrator is not supported.
+The example requires the [Humanitec Operator](https://developer.humanitec.com/integration-and-extensions/humanitec-operator/overview/) to be configured on the cluster and connected to a secret store. The Resource Definition of type `config` will then read the credentials for the `imagePullSecret` from that secret store to populate the actual Kubernetes secret.
 
 To use this mechanism, install the Resource Definitions of this example into your Organization, replacing some placeholder values with the actual values of your setup. Add the appropriate [matching criteria](https://developer.humanitec.com/platform-orchestrator/resources/resource-definitions/#matching-criteria) to the `workload` Definition to match the Workloads you want to have access to the private registry.
 

--- a/resource-definitions/template-driver/imagepullsecrets/config.yaml
+++ b/resource-definitions/template-driver/imagepullsecrets/config.yaml
@@ -14,18 +14,22 @@ entity:
     res_id: regcred
   driver_inputs:
     # These secret references read the credentials from a secret store
+    # Note: Resolving secret references requires the use of the Humanitec Operator
+    # and a secret store configured for it on the target cluster
     secret_refs:
       password:
+        # Replace this value with the name of the secret that's supplying the password
         ref: regcred-password
         # Replace this value with the secret store id that's supplying the password
         store: FIXME
       username:
+        # Replace this value with the name of the secret that's supplying the username
         ref: regcred-username
         # Replace this value with the secret store id that's supplying the username
         store: FIXME
     values:
       secret_name: regcred
-      # Replace this value with the servername of your registry
+      # Replace this value with the servername of your image registry
       server: FIXME
       templates:
         # The init template is used to prepare the "dockerConfigJson" content


### PR DESCRIPTION
This PR removes the mention of the deprecated "Registries" feature from the `imagePullSecrets` example to avoid confusion. It also improves the comments around the use of the Humanitec Operator in that context.