### PR TITLE
Fix missing `aws-role` reference in the break a loop pattern

### DIFF
--- a/resource-graph-patterns/break-a-loop-additional-resource/def-k8s-service-account.yaml
+++ b/resource-graph-patterns/break-a-loop-additional-resource/def-k8s-service-account.yaml
@@ -7,7 +7,7 @@ entity:
     - app_id: example-break-a-loop-additional-resource
   driver_inputs:
     values:
-      role_arn: ${resources['config.sa-name-role-id'].outputs.role_arn}
+      role_arn: ${resources.aws-role.outputs.arn}
       sa_name: ${resources['config.sa-name-role-id'].outputs.sa_name}
       templates:
         outputs: |

--- a/resource-graph-patterns/break-a-loop-additional-resource/score.yaml
+++ b/resource-graph-patterns/break-a-loop-additional-resource/score.yaml
@@ -7,9 +7,6 @@ containers:
   busybox:
     image: busybox:latest
 
-    variables:
-      BUCKET_NAME: ${resources.my-s3.bucket}
-
     command:
       - /bin/sh
     args:
@@ -18,7 +15,3 @@ containers:
       # STDOUT every 15 seconds. This can be seen in the container logs in the
       # Humanitec UI.
       - "while true; do set; sleep 15; done"
-
-resources:
-  my-s3:
-    type: s3


### PR DESCRIPTION
Fix the missing link between `k8s-service-account` and the `aws-role` to have this example working: https://developer.humanitec.com/examples/resource-graph-patterns/break-a-loop-additional-resource/.