### PR TITLE
Show how to access a service of another workload

### DIFF
--- a/score/service/README.md
+++ b/score/service/README.md
@@ -3,3 +3,5 @@ Define how a service for the Workload is configured.
 Refer to the [service feature](https://developer.humanitec.com/integration-and-extensions/workload-profiles/features/#humanitecservice) for configuration details.
 
 You may optionally set annotations and labels on the Kubernetes `Service` object through a Score extension file.
+
+Other workloads of the same Application may access a workload's service through a `service` Resource declared in Score. That resource's `name` output will resolve to the Kubernetes-internal DNS name of the other workload's service. See the Score files for the specific setup.

--- a/score/service/score-consuming-a-service.yaml
+++ b/score/service/score-consuming-a-service.yaml
@@ -1,0 +1,16 @@
+# This Score file defines a workload accessing another workload through its service
+apiVersion: score.dev/v1b1
+metadata:
+  name: workload-consuming-a-service
+
+containers:
+  demo:
+    image: .
+    variables:
+      # This placeholder will resolve to the K8s-internal DNS name of the other workload's service
+      SERVICE_ADDR: "${resources.my-workload.name}:8080"
+resources:
+  # The name of this resource needs to correspond with the name
+  # of the workload whose service you wish to access
+  my-workload:
+    type: service

--- a/score/service/score.yaml
+++ b/score/service/score.yaml
@@ -1,10 +1,11 @@
+# This Score file defines a workload declaring a service
 apiVersion: score.dev/v1b1
 metadata:
   name: my-workload
 
 containers:
   demo:
-    image: registry/my-image:1.0.0
+    image: .
 service:
   ports:
     www:


### PR DESCRIPTION
This PR expands the Score `service` example to show how to access a service of another workload.