### PR TITLE
Consolidate service account for Container Driver

### DIFF
--- a/resource-definitions/container-driver/inline-terraform/k8s-cluster-runner-config.tf
+++ b/resource-definitions/container-driver/inline-terraform/k8s-cluster-runner-config.tf
@@ -12,7 +12,7 @@ resource "humanitec_resource_definition" "config-container-driver" {
         ]
         "shared_directory" = "/home/runneruser/workspace"
         "namespace"        = "humanitec-runner"
-        "service_account"  = "humanitec-runner-job"
+        "service_account"  = "humanitec-runner"
         "pod_template"     = <<END_OF_TEXT
 spec:
   imagePullSecrets:

--- a/resource-definitions/container-driver/inline-terraform/k8s-cluster-runner-config.yaml
+++ b/resource-definitions/container-driver/inline-terraform/k8s-cluster-runner-config.yaml
@@ -19,7 +19,7 @@ entity:
         # Change to the namespace name you created to host the Kubernetes Job created by the Driver.
         namespace: humanitec-runner
         # Change to the service account name with permissions to create secrets/configmaps in the Kubernetes Job namespace you created.
-        service_account: humanitec-runner-job
+        service_account: humanitec-runner
         # This assumes a secret with the given name exists in the desired namespace and it contains the credentials to pull the job image from the private registry.
         pod_template: |
           spec:

--- a/resource-definitions/container-driver/private-git-repo/k8s-cluster-runner-config.tf
+++ b/resource-definitions/container-driver/private-git-repo/k8s-cluster-runner-config.tf
@@ -12,7 +12,7 @@ resource "humanitec_resource_definition" "config-container-driver" {
         ]
         "shared_directory" = "/home/runneruser/workspace"
         "namespace"        = "humanitec-runner"
-        "service_account"  = "humanitec-runner-job"
+        "service_account"  = "humanitec-runner"
         "pod_template"     = <<END_OF_TEXT
 spec:
   imagePullSecrets:

--- a/resource-definitions/container-driver/private-git-repo/k8s-cluster-runner-config.yaml
+++ b/resource-definitions/container-driver/private-git-repo/k8s-cluster-runner-config.yaml
@@ -19,7 +19,7 @@ entity:
         # Change to the namespace name you created to host the Kubernetes Job created by the Driver.
         namespace: humanitec-runner
         # Change to the service account name with permissions to create secrets/configmaps in the Kubernetes Job namespace you created.
-        service_account: humanitec-runner-job
+        service_account: humanitec-runner
         # This assumes a secret with the given name exists in the desired namespace and it contains the credentials to pull the job image from the private registry.
         pod_template: |
           spec:

--- a/resource-definitions/container-driver/terraform/s3.tf
+++ b/resource-definitions/container-driver/terraform/s3.tf
@@ -14,7 +14,7 @@ resource "humanitec_resource_definition" "aws-s3" {
         ]
         "shared_directory" = "/home/runneruser/workspace"
         "namespace"        = "humanitec-runner"
-        "service_account"  = "humanitec-container-runner"
+        "service_account"  = "humanitec-runner"
       }
       "cluster" = {
         "account" = "my-org/my-aws-cloud-account"

--- a/resource-definitions/container-driver/terraform/s3.yaml
+++ b/resource-definitions/container-driver/terraform/s3.yaml
@@ -23,7 +23,7 @@ entity:
         # Change to the namespace name you created to host the Kubernetes Job created by the Driver.
         namespace: humanitec-runner
         # Change to the service account name with permissions to create secrets/configmaps in the Kubernetes Job namespace you created.
-        service_account: humanitec-container-runner
+        service_account: humanitec-runner
       cluster:
         # Update to your cloud account
         account: my-org/my-aws-cloud-account


### PR DESCRIPTION
This PR consolidates the mentions of a K8s service account for the Container Driver to the value `humanitec-runner`. We are aligning it accordingly in the developer docs.