### PR TITLE
Example for Container Driver secret variables injection

### DIFF
--- a/resource-definitions/container-driver/secrets/README.md
+++ b/resource-definitions/container-driver/secrets/README.md
@@ -1,0 +1,19 @@
+This example shows how to inject secret values into a container run by the [Container Driver](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/container/) from a downstream Resource in the Graph.
+
+The same pattern applies to any Virtual Driver that wraps the Container Driver.
+
+The example consists of these files:
+
+- [mysql.yaml](./mysql.yaml): A Resource Definition of type `mysql` using the Container Driver. It uses an external Git repository to retrieve some IaC code, e.g. Terraform, for execution. The key element for this example is the setting of environment variables for the Container Driver runner in this section. The variables values themselves are obtained as secret outputs from a `mysql-instance` Resource:
+
+```yaml
+entity:
+  driver_inputs:
+    secret_refs:
+      job:
+        variables:
+          TF_VAR_...
+```
+
+- [mysql-instance.yaml](./mysql-instance.yaml): A Resource Definition of type `mysql-instance` using the Echo Driver, so the Orchestrator is not managing the instance but just providing access data to the upstream `mysql` Resource.
+- [runner-config.yaml](./runner-config.yaml): Externalized configuration values for the Container Driver in a `config` Resource Definition

--- a/resource-definitions/container-driver/secrets/mysql-instance.yaml
+++ b/resource-definitions/container-driver/secrets/mysql-instance.yaml
@@ -1,0 +1,29 @@
+# This Resource Definition uses the Echo Driver to represent a mysql-instance
+# without managing it.
+# In particular, it returns secret outputs for username and password, to be
+# consumed by other upstream resources in the Graph.
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: container-driver-secrets-example-mysql-instance
+entity:
+  name: container-driver-secrets-example-mysql-instance
+  type: mysql-instance
+  driver_type: humanitec/echo
+  driver_inputs:
+    values:
+      name: my-instance
+      host: products.mysql.dev.example.com
+      port: 5432
+    secret_refs:
+      # Read secret values from a secret store
+      # which needs to be configured on the target cluster
+      username:
+        store: my-secret-store
+        ref: my-instance-username
+      password:
+        store: my-secret-store
+        ref: my-instance-password
+  # Adjust matching criteria as required
+  criteria:
+  - app_id: container-driver-secrets-example

--- a/resource-definitions/container-driver/secrets/mysql.yaml
+++ b/resource-definitions/container-driver/secrets/mysql.yaml
@@ -1,0 +1,46 @@
+# This Resource Definition shows how to inject secret values into a container run by the Container Driver
+# to create a MySQL database in a MySQL instance. It does not show how to actually create the db.
+# It reads secret values from a downstream "mysql-instance" Resource and shows how to inject them
+# as environment variables into the runner container
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: container-driver-secrets-example-mysql
+entity:
+  name: container-driver-secrets-example-mysql
+  type: mysql
+  driver_type: humanitec/container
+  driver_account: my-aws-cloud-account
+  driver_inputs:
+    values:
+      # Source job and cluster configuration from a config resource
+      job: ${resources['config.runner'].outputs.job}
+      cluster: ${resources['config.runner'].outputs.cluster}
+      # Needed to authenticate to aws TF provider in the TF code passed via files inputs
+      # These values are provided via the `driver_account` configured above
+      credentials_config:
+        environment:
+          AWS_ACCESS_KEY_ID: AccessKeyId
+          AWS_SECRET_ACCESS_KEY: SecretAccessKey
+      # Change to match your IaC code repository
+      source:
+        ref: refs/heads/main
+        url: https://github.com/my-org/my-repo.git
+    # All references to secret outputs of another resource MUST be placed in the `secret_refs` section
+    secret_refs:
+      job:
+        # Setting environment variables in the container to be picked up by Terraform code
+        variables:
+          TF_VAR_mysql-instance-username:
+            value: ${resources['mysql-instance.default'].outputs.username}
+          TF_VAR_mysql-instance-password:
+            value: ${resources['mysql-instance.default'].outputs.password}
+      source:
+        # Read a GitHub Personal Access Token for repo access from a secret store
+        password:
+          store: my-secret-store
+          ref: my-path-to-git-token
+  # Adjust matching criteria as required
+  criteria:
+  - app_id: container-driver-secrets-example
+

--- a/resource-definitions/container-driver/secrets/runner-config.yaml
+++ b/resource-definitions/container-driver/secrets/runner-config.yaml
@@ -1,0 +1,34 @@
+# This Resource Definition provides configuration values for the Container Driver
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: container-driver-secrets-example-config
+entity:
+  name: container-driver-secrets-example-config
+  type: config
+  driver_type: humanitec/echo
+  driver_inputs:
+    values:
+      job:
+        # Change to match the image you built to run the IaC of your choice
+        image: ghcr.io/my-registry/container-driver-runner:1.0.1
+        # Change to match the command to run your image or remove it if you want to use the image entrypoint
+        command: ["/opt/container"]
+        # Change to match the mount point of your shared directory
+        shared_directory: /home/runneruser/workspace
+      # Change to match the configuration of your target cluster
+      cluster:
+        account: my-org/my-aws-cloud-account
+        cluster:
+          cluster_type: eks
+          loadbalancer: 10.10.10.10
+          name: my-demo-cluster
+          region: eu-west-3
+    # Change to match the desired agent (if any)
+    secret_refs:
+      agent_url: 
+        value: ${resources['agent.default#agent'].outputs.url}
+  # Adjust matching criteria as required
+  criteria:
+  - app_id: container-driver-secrets-example
+    class: runner


### PR DESCRIPTION
This PR adds an example showing how to inject secret values into a Container Runner from a downstream resource.

The only way found to be working is using environment variables.