### PR TITLE
Use cookie to store volumeUid

### DIFF
--- a/resource-definitions/template-driver/volumes/volume-nfs.yaml
+++ b/resource-definitions/template-driver/volumes/volume-nfs.yaml
@@ -13,11 +13,19 @@ entity:
   driver_inputs:
     values:
       templates:
+        cookie: |
+          # Store the volumeUid in a cookie to be reused for subsequent deployments
+          volumeUid: {{ .init.volumeUid }}
         init: |
           # Generate a unique id for each pv/pvc combination.
           # Every Workload will have a separate pv and pvc created for it,
           # but pointing to the same NFS server endpoint.
-          volumeUid: {{ randNumeric 4 }}-{{ randNumeric 4 }}
+          volumeUid: |
+            {{- if and .cookie .cookie.volumeUid }}
+              {{- .cookie.volumeUid }}
+            {{- else }}
+              {{ randNumeric 4 }}-{{ randNumeric 4 }}
+            {{- end }}
           pvBaseName: pv-tmpl-
           pvcBaseName: pvc-tmpl-
           volBaseName: vol-tmpl-

--- a/resource-definitions/template-driver/volumes/volume-nfs.yaml
+++ b/resource-definitions/template-driver/volumes/volume-nfs.yaml
@@ -20,12 +20,11 @@ entity:
           # Generate a unique id for each pv/pvc combination.
           # Every Workload will have a separate pv and pvc created for it,
           # but pointing to the same NFS server endpoint.
-          volumeUid: |
-            {{- if and .cookie .cookie.volumeUid }}
-              {{- .cookie.volumeUid }}
-            {{- else }}
-              {{ randNumeric 4 }}-{{ randNumeric 4 }}
-            {{- end }}
+          {{- if and .cookie .cookie.volumeUid }}
+          volumeUid: {{ .cookie.volumeUid }}
+          {{- else }}
+          volumeUid: {{ randNumeric 4 }}-{{ randNumeric 4 }}
+          {{- end }}
           pvBaseName: pv-tmpl-
           pvcBaseName: pvc-tmpl-
           volBaseName: vol-tmpl-


### PR DESCRIPTION
This PR fixes the "volume-nfs" example to now store the random volume name in a cookie so it is reused across subsequent deployments. Currently, a new ID would be generated with every deployment, causing a new volume to be created.

Note: the `.tf` variant will be created automatically.