### PR TITLE
base-env example with secret store

### DIFF
--- a/resource-definitions/template-driver/secret-store/README.md
+++ b/resource-definitions/template-driver/secret-store/README.md
@@ -2,6 +2,8 @@ This example shows how you can create an Environment-local [Secret store](https:
 
 The mechanism uses a Resource Definition of type [base-env](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#base-env) to create a `SecretStore` Custom Resource (CR) in the Kubernetes namespace of the target Environment.
 
+You have a choice to make the `SecretStore` `name` either context-agnostic, i.e. static, or context-specific using [Placeholders](https://developer.humanitec.com/platform-orchestrator/reference/placeholders/). Note that secret references used for accessing secrets from that store [cannot currently use Placeholders as well](https://developer.humanitec.com/platform-orchestrator/security/secret-references/#limitations), so involved parties will have to follow an agreed on convention to use the same store names.
+
 The example follows the recommended practice to source configuration values for the `SecretStore` object from a `config` Resource.
 
 The secret store defined in the `base-env` may be used normally in [Secret references](https://developer.humanitec.com/platform-orchestrator/security/secret-references/) using the secret store ID specified in `metadata.name` of the `SecretStore` manifest.

--- a/resource-definitions/template-driver/secret-store/README.md
+++ b/resource-definitions/template-driver/secret-store/README.md
@@ -1,0 +1,14 @@
+This example shows how you can create an Environment-local [Secret store](https://developer.humanitec.com/guides/platform-engineers/security/connect-secret-stores/overview/) definition with each Deployment.
+
+The mechanism uses a Resource Definition of type [base-env](https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#base-env) to create a `SecretStore` Custom Resource (CR) in the Kubernetes namespace of the target Environment.
+
+The example follows the recommended practice to source configuration values for the `SecretStore` object from a `config` Resource.
+
+The secret store defined in the `base-env` may be used normally in [Secret references](https://developer.humanitec.com/platform-orchestrator/security/secret-references/) using the secret store ID specified in `metadata.name` of the `SecretStore` manifest.
+
+> In edge cases, an Operator error may occur on the first deployment using this mechanism saying "secret store <name> is not found in application and operator system namespaces". This may be due to the timing of the `SecretStore` manifest creation and a Resource requiring it to be present, not reoccur for all subsequent deployments given the setup is otherwise correct.
+
+Two Resource Definitions are provided:
+
+- [`base-env-secretstore.yaml`](./base-env-secretstore.yaml): Defines the `base-env` creating the `SecretStore` CR in the target namespace of the Environment
+- [`config-secretstore.yaml`](./config-secretstore.yaml): Defines the `config` Resource for providing parameters to the `base-env` to define the `SecretStore`

--- a/resource-definitions/template-driver/secret-store/base-env-secretstore.yaml
+++ b/resource-definitions/template-driver/secret-store/base-env-secretstore.yaml
@@ -1,0 +1,30 @@
+# This Resource Definition uses the base-env Resource type to create
+# a SecretStore definition in the namespace of the Application Environment
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: base-env
+entity:
+  name: base-env
+  type: base-env
+  driver_type: humanitec/template
+  driver_inputs:
+    values:
+      templates:
+        manifests: |-
+          secretstore.yaml:
+            location: namespace
+            data:
+              apiVersion: humanitec.io/v1alpha1
+              kind: SecretStore
+              metadata:
+                name: my-local-gsm
+              spec:
+                # Configure the secret store according to its type
+                # This example shows a Google Cloud Secret Manager
+                gcpsm:
+                  auth: {}
+                  projectID: ${resources['config.secretstore'].outputs.project_id}
+  # Adjust matching criteria as required
+  criteria:
+  - app_id: my-secretstore-app

--- a/resource-definitions/template-driver/secret-store/base-env-secretstore.yaml
+++ b/resource-definitions/template-driver/secret-store/base-env-secretstore.yaml
@@ -18,7 +18,10 @@ entity:
               apiVersion: humanitec.io/v1alpha1
               kind: SecretStore
               metadata:
+                # Use this line for context-agnostic naming:
                 name: my-local-gsm
+                # Use this line instead for context-specific naming:
+                # name: ${context.app.id}-${context.env.id}
               spec:
                 # Configure the secret store according to its type
                 # This example shows a Google Cloud Secret Manager

--- a/resource-definitions/template-driver/secret-store/config-secretstore.yaml
+++ b/resource-definitions/template-driver/secret-store/config-secretstore.yaml
@@ -1,0 +1,17 @@
+# This Resource Definition uses the Echo Driver to provide configuration values
+apiVersion: entity.humanitec.io/v1b1
+kind: Definition
+metadata:
+  id: secretstore-config
+entity:
+  name: secretstore-config
+  type: config
+  driver_type: humanitec/echo
+  driver_inputs:
+    # Any Driver inputs will be returned as outputs by the Echo Driver
+    values:
+      project_id: my-gcp-project-id
+  # Adjust matching criteria as required
+  criteria:
+  - class: secretstore
+    app_id: my-secretstore-app


### PR DESCRIPTION
This PR introduces a new example showing how to add an Environment-local secret store via a `base-env` Resource Definition.

Once the example is available, we can use it in extending the secret store documentation on the Orchestrator.